### PR TITLE
DEV-29347 Log external content if not null

### DIFF
--- a/src/main/java/com/acrolinx/sidebar/swt/AcrolinxSidebarSWT.java
+++ b/src/main/java/com/acrolinx/sidebar/swt/AcrolinxSidebarSWT.java
@@ -350,7 +350,9 @@ public class AcrolinxSidebarSWT implements AcrolinxSidebar
         logger.debug("Request content JSON compatible: " + content);
 
         final ExternalContent externalContent = client.getEditorAdapter().getExternalContent();
-        logger.debug("External Content: " + externalContent.toString());
+        if (externalContent != null) {
+            logger.debug("External Content: " + externalContent.toString());
+        }
 
         final CheckOptions checkOptions = getCheckSettingsFromClient(selectionRequested, externalContent);
         logger.debug("Check options: " + checkOptions.toString());


### PR DESCRIPTION
External content could be null.

Logging external content causes toString() to be invoked on null, throwing NPE

The fix on logs External Content if it's not null