### PR TITLE
DEV-30114; add full support for external content checking

### DIFF
--- a/src/main/java/com/acrolinx/sidebar/jfx/AcrolinxSidebarPlugin.java
+++ b/src/main/java/com/acrolinx/sidebar/jfx/AcrolinxSidebarPlugin.java
@@ -155,7 +155,7 @@ abstract class AcrolinxSidebarPlugin
 
         JFXUtils.invokeInJFXThread(() -> {
             try {
-                logger.info(checkOptions.toString());
+                logger.debug(checkOptions.toString());
                 final String nameVariableCheckText = "checkText";
                 final JSObject jsObject = getWindowObject();
                 jsObject.setMember(nameVariableCheckText, checkContent.getContent());

--- a/src/main/java/com/acrolinx/sidebar/lookup/ContentNode.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/ContentNode.java
@@ -10,5 +10,6 @@ public interface ContentNode
 
     String getContent();
 
-    ReferenceTreeNode getAsXMLFragment();
+    String getAsXMLFragment();
 }
+

--- a/src/main/java/com/acrolinx/sidebar/lookup/ContentNode.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/ContentNode.java
@@ -10,5 +10,5 @@ public interface ContentNode
 
     String getContent();
 
-    String getAsXMLFragment();
+    ReferenceTreeNode getAsXMLFragment();
 }

--- a/src/main/java/com/acrolinx/sidebar/lookup/ExternalContentNode.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/ExternalContentNode.java
@@ -1,3 +1,4 @@
+/* Copyright (c) 2022-present Acrolinx GmbH */
 package com.acrolinx.sidebar.lookup;
 
 public interface ExternalContentNode extends ContentNode {

--- a/src/main/java/com/acrolinx/sidebar/lookup/ExternalContentNode.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/ExternalContentNode.java
@@ -1,0 +1,6 @@
+package com.acrolinx.sidebar.lookup;
+
+public interface ExternalContentNode extends ContentNode {
+
+    ReferenceTreeNode getReferenceTree();
+}

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
@@ -156,9 +156,9 @@ public class LookupForResolvedEditorViews
                 String contentNodeXMLString;
                     // Try to lookup xml fragment in document.
                 Optional<IntRange> correctedMatchRange;
-                if(match instanceof ExternalAbstractMatch && !((ExternalAbstractMatch) match).hasExternalContentMatches()) {
+                if(!(match instanceof ExternalAbstractMatch) || !((ExternalAbstractMatch) match).hasExternalContentMatches()) {
                     contentNodeXMLString = contentNode.getAsXMLFragment();
-                    if (contentNodeXMLString == "") return;
+                    if (contentNodeXMLString == "" || contentNodeXMLString == null) return;
                     final int fragmentStartOffsetInCurrentDocument = findFragmentStartOffsetInCurrentDocument(contentNodeXMLString, match);
                     final int fragmentEndOffsetInCurrentDocument = findFragmentEndOffsetInCurrentDocument(contentNodeXMLString, match, currentDocumentContent);
                     final String relativeFragment = currentDocumentContent.substring(fragmentStartOffsetInCurrentDocument, fragmentEndOffsetInCurrentDocument);

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
@@ -382,7 +382,7 @@ public class LookupForResolvedEditorViews
             String resolvedViewContent)
     {
         matches.forEach(match -> {
-            if (match.getContent().length() <= 0) return;
+            if (match.getContent().length() <= 1) return;
             if (match instanceof ExternalAbstractMatch && ((ExternalAbstractMatch) match).hasExternalContentMatches()) return;
 
             String contentUpToMatch = currentDocumentContent.substring(0,

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
@@ -158,7 +158,7 @@ public class LookupForResolvedEditorViews
                 Optional<IntRange> correctedMatchRange;
                 if(!(match instanceof ExternalAbstractMatch) || !((ExternalAbstractMatch) match).hasExternalContentMatches()) {
                     contentNodeXMLString = contentNode.getAsXMLFragment();
-                    if (contentNodeXMLString == "" || contentNodeXMLString == null) return;
+                    if (contentNodeXMLString.equals("") || contentNodeXMLString == null) return;
                     final int fragmentStartOffsetInCurrentDocument = findFragmentStartOffsetInCurrentDocument(contentNodeXMLString, match);
                     final int fragmentEndOffsetInCurrentDocument = findFragmentEndOffsetInCurrentDocument(contentNodeXMLString, match, currentDocumentContent);
                     final String relativeFragment = currentDocumentContent.substring(fragmentStartOffsetInCurrentDocument, fragmentEndOffsetInCurrentDocument);

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
@@ -2,7 +2,7 @@
 
 package com.acrolinx.sidebar.lookup;
 
-import java.sql.Ref;
+
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -203,7 +203,7 @@ public class LookupForResolvedEditorViews
             logger.error("calcCorrectedMatch was called despite match not having ExternalContentMatches");
             return Optional.empty();
         }
-        if(xmlTree.referenceChildren.size() == 0) {
+        if(xmlTree.referenceChildren.isEmpty()) {
             logger.warn("No reference Children while match has external ContentMatches");
             return Optional.empty();
         }
@@ -227,7 +227,9 @@ public class LookupForResolvedEditorViews
 
             totalDelta += externalContentRangeMinimum;
 
-            if (nextExternalContentMatch.getExternalContentMatches().size() > 0) {
+            if (nextExternalContentMatch.getExternalContentMatches().isEmpty()) {
+                nextExternalContentMatch = null;
+            } else {
                 Optional<ReferenceTreeNode> optionalReferenceTreeNode = referenceChildren.stream().filter( n -> n.getStartOffsetInParent() == externalContentRangeMinimum).findFirst();
                 if(optionalReferenceTreeNode.isPresent()) {
                     referencedContentTreeNode = optionalReferenceTreeNode.get();
@@ -235,8 +237,6 @@ public class LookupForResolvedEditorViews
                     return Optional.empty();
                 }
                 nextExternalContentMatch = nextExternalContentMatch.getExternalContentMatches().get(0);
-            } else {
-                nextExternalContentMatch = null;
             }
         }
         return Optional.of(new IntRange(totalDelta, totalDelta + externalContentRange.getMaximumInteger() - externalContentRange.getMinimumInteger()));
@@ -269,7 +269,7 @@ public class LookupForResolvedEditorViews
     {
         logger.debug(contentNodeXMLString);
         logger.debug(textContent);
-        textContent = textContent.replaceAll("\u0000"," ");
+        textContent = textContent.replace("\u0000"," ");
         List<DiffMatchPatch.Diff> diffsNode = Lookup.getDiffs(contentNodeXMLString, textContent);
         List<OffsetAlign> offsetMappingArray = Lookup.createOffsetMappingArray(diffsNode);
 

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
@@ -263,7 +263,7 @@ public class LookupForResolvedEditorViews
     {
         logger.debug(contentNodeXMLString);
         logger.debug(textContent);
-
+        textContent = textContent.replaceAll("\u0000"," ");
         List<DiffMatchPatch.Diff> diffsNode = Lookup.getDiffs(contentNodeXMLString, textContent);
         List<OffsetAlign> offsetMappingArray = Lookup.createOffsetMappingArray(diffsNode);
 

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
@@ -181,9 +181,14 @@ public class LookupForResolvedEditorViews
                     else {
                         //todo: Is this get(0) ok?
                         ExternalContentMatch externalContentMatch = ((AcrolinxMatch) match).getExternalContentMatches().get(0);
+                        IntRange range = externalContentMatch.getRange();
+                        while (externalContentMatch.getExternalContentMatches().size() > 0) {
+                            externalContentMatch = externalContentMatch.getExternalContentMatches().get(0);
+                            range = new IntRange(range.getMinimumInteger() + externalContentMatch.getRange().getMinimumInteger(), range.getMinimumInteger() + externalContentMatch.getRange().getMaximumInteger());
+                        }
 
                         diffXMLFragmentWithNodeContentFragment(match, contentNode,
-                                startOffset, textContent, rangeContent, externalContentMatch.getRange());
+                                startOffset, textContent, rangeContent, range);
                     }
 
                 }

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
@@ -124,7 +124,7 @@ public class LookupForResolvedEditorViews
                     + ("".equals(match.getContent()) || match.getContent().equalsIgnoreCase(" ")));
             boolean matchLineBreakOrTab = match.getContent().matches("[\\n\\r\\t]+");
             logger.debug("match content is linebreak or tab? " + matchLineBreakOrTab);
-            return (("".equals(match.getContent()) || match.getContent().equals(" ") || matchLineBreakOrTab) && ignore);
+            return (("".equals(match.getContent()) || match.getContent().equals(" ")  || matchLineBreakOrTab) && ignore);
         }).collect(Collectors.toList());
     }
 
@@ -148,7 +148,7 @@ public class LookupForResolvedEditorViews
             logger.debug("Get node startOffset: " + contentNode.getStartOffset());
             String textContent = contentNode.getContent();
             String rangeContent = match.getContent();
-            if (StringUtils.countMatches(textContent, rangeContent) == 1) {
+            if (StringUtils.countMatches(textContent, rangeContent) == 1 && (!match.hasExternalContentMatches() || match.getExternalContentMatches().size() < 2)) {
                 int i = textContent.indexOf(rangeContent);
                 AbstractMatch copy = match.setRange(
                         new IntRange(startOffset + i, startOffset + i + rangeContent.length()));
@@ -377,20 +377,21 @@ public class LookupForResolvedEditorViews
             String resolvedViewContent)
     {
         matches.forEach(match -> {
-            if (match.getContent().length() > 1) {
-                String contentUpToMatch = currentDocumentContent.substring(0,
-                        match.getRange().getMaximumInteger()).replaceAll("</?\\w+.*?>", "");
-                int occurrence = StringUtils.countMatches(contentUpToMatch, match.getContent());
-                int ordinalIndex = StringUtils.ordinalIndexOf(resolvedViewContent, match.getContent(), occurrence);
+            if (match.getContent().length() <= 0) return;
+            if (match.hasExternalContentMatches()) return;
 
-                if (ordinalIndex > 0) {
-                    AbstractMatch copy = match.setRange(
-                            new IntRange(ordinalIndex, ordinalIndex + match.getContent().length()));
-                    logForDebugFoundContent(match);
-                    logForDebugCurrentRanges(copy);
-                    newRanges.add(copy);
-                    mappedRanges.add(match);
-                }
+            String contentUpToMatch = currentDocumentContent.substring(0,
+                    match.getRange().getMaximumInteger()).replaceAll("</?\\w+.*?>", "");
+            int occurrence = StringUtils.countMatches(contentUpToMatch, match.getContent());
+            int ordinalIndex = StringUtils.ordinalIndexOf(resolvedViewContent, match.getContent(), occurrence);
+
+            if (ordinalIndex > 0) {
+                AbstractMatch copy = match.setRange(
+                        new IntRange(ordinalIndex, ordinalIndex + match.getContent().length()));
+                logForDebugFoundContent(match);
+                logForDebugCurrentRanges(copy);
+                newRanges.add(copy);
+                mappedRanges.add(match);
             }
         });
     }

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
@@ -228,7 +228,6 @@ public class LookupForResolvedEditorViews
                 } else {
                     return Optional.empty();
                 }
-                //todo: Is this get(0) ok?
                 nextExternalContentMatch = nextExternalContentMatch.getExternalContentMatches().get(0);
             } else {
                 nextExternalContentMatch = null;

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
@@ -158,7 +158,7 @@ public class LookupForResolvedEditorViews
                 Optional<IntRange> correctedMatchRange;
                 if(!(match instanceof ExternalAbstractMatch) || !((ExternalAbstractMatch) match).hasExternalContentMatches()) {
                     contentNodeXMLString = contentNode.getAsXMLFragment();
-                    if (contentNodeXMLString.equals("") || contentNodeXMLString == null) return;
+                    if (contentNodeXMLString == null || contentNodeXMLString.equals("") ) return;
                     final int fragmentStartOffsetInCurrentDocument = findFragmentStartOffsetInCurrentDocument(contentNodeXMLString, match);
                     final int fragmentEndOffsetInCurrentDocument = findFragmentEndOffsetInCurrentDocument(contentNodeXMLString, match, currentDocumentContent);
                     final String relativeFragment = currentDocumentContent.substring(fragmentStartOffsetInCurrentDocument, fragmentEndOffsetInCurrentDocument);

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupRangesDiff.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupRangesDiff.java
@@ -76,7 +76,7 @@ public class LookupRangesDiff extends LookupRanges
 
         return matches.stream().map((match) -> {
 
-            if(match.getExternalContentMatches().size() > 0) {
+            if(!match.getExternalContentMatches().isEmpty()) {
                List<ExternalContentMatch> newMatches = getExternalContentMatchesWithCorrectedRanges(match.getExternalContentMatches(),checkedText,changedText);
                match.setExternalContentMatches(newMatches);
             }

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupRangesDiff.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupRangesDiff.java
@@ -17,10 +17,13 @@ import com.acrolinx.sidebar.LookupRanges;
 import com.acrolinx.sidebar.pojo.document.AbstractMatch;
 import com.acrolinx.sidebar.pojo.document.IntRange;
 import com.acrolinx.sidebar.utils.DiffMatchPatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("WeakerAccess")
 public class LookupRangesDiff extends LookupRanges
 {
+   private Logger logger = LoggerFactory.getLogger(LookupRangesDiff.class);
 
     @Override
     public Optional<List<? extends AbstractMatch>> getMatchesWithCorrectedRanges(String checkedText, String changedText,
@@ -56,7 +59,6 @@ public class LookupRangesDiff extends LookupRanges
             if (!acrolinxMatch.hasExternalContentMatches())
                 return match;
 
-            //todo: this needs to become recursive for multiple levels of referenced content
             List<ExternalContentMatch> externalContentMatches = acrolinxMatch.getExternalContentMatches();
 
             List<ExternalContentMatch> correctedMatches = getExternalContentMatchesWithCorrectedRanges(externalContentMatches,
@@ -102,6 +104,7 @@ public class LookupRangesDiff extends LookupRanges
         if (correctedMatch.isPresent()) {
             return match.setRange(correctedMatch.get());
         } else {
+            logger.warn("Could not adjust external Content Match");
             return match;
         }
     }

--- a/src/main/java/com/acrolinx/sidebar/lookup/ReferenceTreeNode.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/ReferenceTreeNode.java
@@ -1,3 +1,4 @@
+/* Copyright (c) 2022-present Acrolinx GmbH */
 package com.acrolinx.sidebar.lookup;
 
 import java.util.ArrayList;

--- a/src/main/java/com/acrolinx/sidebar/lookup/ReferenceTreeNode.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/ReferenceTreeNode.java
@@ -1,0 +1,56 @@
+package com.acrolinx.sidebar.lookup;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReferenceTreeNode {
+
+    private String referencingTag = "";
+    private String unresolvedContent = "";
+    private String resolvedContent = "";
+
+    private int startOffsetInParent = 0;
+
+    public final List<ReferenceTreeNode> referenceChildren = new ArrayList<>();
+
+    public void setStartOffsetInParent(int newStartOffset) {
+        startOffsetInParent = newStartOffset;
+    }
+
+    public int getStartOffsetInParent() {
+        return startOffsetInParent;
+    }
+
+    public void setUnresolvedContent(String newString) {
+        unresolvedContent = newString;
+    }
+
+    public void setResolvedContent(String newString) {
+        resolvedContent = newString;
+    }
+
+    public String getReferencingTag() {
+        return referencingTag;
+    }
+
+    public void setReferencingTag(String newString) {
+        referencingTag = newString;
+    }
+
+    public String getUnresolvedContent() {
+        return unresolvedContent;
+    }
+
+    public String getResolvedContent() {
+        return resolvedContent;
+    }
+
+    public int getUnresolvedLength() {
+        return unresolvedContent.length();
+    }
+
+    public int getResolvedLength() {
+        return resolvedContent.length();
+    }
+
+}

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/AbstractMatch.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/AbstractMatch.java
@@ -4,10 +4,12 @@ package com.acrolinx.sidebar.pojo.document;
 
 import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public abstract class AbstractMatch
 {
+
     public abstract IntRange getRange();
 
     public abstract String getContent();
@@ -16,7 +18,8 @@ public abstract class AbstractMatch
 
     public abstract AbstractMatch copy();
 
-    public abstract boolean hasExternalContentMatches();
-    public abstract List<ExternalContentMatch> getExternalContentMatches();
+
 
 }
+
+

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/AbstractMatch.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/AbstractMatch.java
@@ -2,6 +2,10 @@
 
 package com.acrolinx.sidebar.pojo.document;
 
+import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
+
+import java.util.List;
+
 public abstract class AbstractMatch
 {
     public abstract IntRange getRange();
@@ -11,4 +15,8 @@ public abstract class AbstractMatch
     public abstract AbstractMatch setRange(IntRange range);
 
     public abstract AbstractMatch copy();
+
+    public abstract boolean hasExternalContentMatches();
+    public abstract List<ExternalContentMatch> getExternalContentMatches();
+
 }

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/AbstractMatch.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/AbstractMatch.java
@@ -2,11 +2,6 @@
 
 package com.acrolinx.sidebar.pojo.document;
 
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
-
-import java.util.ArrayList;
-import java.util.List;
-
 public abstract class AbstractMatch
 {
 
@@ -17,9 +12,4 @@ public abstract class AbstractMatch
     public abstract AbstractMatch setRange(IntRange range);
 
     public abstract AbstractMatch copy();
-
-
-
 }
-
-

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/AcrolinxMatch.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/AcrolinxMatch.java
@@ -6,9 +6,8 @@ import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
 
 import java.util.List;
 
-//todo: Refactor for Matches with External Matches
 @SuppressWarnings({"unused", "WeakerAccess"})
-public class AcrolinxMatch extends AbstractMatch
+public class AcrolinxMatch extends ExternalAbstractMatch
 {
     private final String content;
     private IntRange extractedRange;

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/AcrolinxMatch.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/AcrolinxMatch.java
@@ -77,11 +77,12 @@ public class AcrolinxMatch extends AbstractMatch
             return new AcrolinxMatch(range, content);
         }
     }
-
+    @Override
     public boolean hasExternalContentMatches () {
         return this.externalContentMatches != null && this.getExternalContentMatches().size() > 0;
     }
 
+    @Override
     public List<ExternalContentMatch> getExternalContentMatches() {
         return this.externalContentMatches;
     }

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/ExternalAbstractMatch.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/ExternalAbstractMatch.java
@@ -1,0 +1,11 @@
+package com.acrolinx.sidebar.pojo.document;
+
+import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
+
+import java.util.List;
+
+public abstract class ExternalAbstractMatch extends AbstractMatch {
+    public abstract boolean hasExternalContentMatches();
+
+    public abstract List<ExternalContentMatch> getExternalContentMatches();
+}

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/ExternalAbstractMatch.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/ExternalAbstractMatch.java
@@ -1,3 +1,4 @@
+/* Copyright (c) 2022-present Acrolinx GmbH */
 package com.acrolinx.sidebar.pojo.document;
 
 import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/externalContent/ExternalContentMatch.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/externalContent/ExternalContentMatch.java
@@ -6,6 +6,7 @@ package com.acrolinx.sidebar.pojo.document.externalContent;
 import com.acrolinx.sidebar.pojo.document.IntRange;
 import com.google.gson.Gson;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ExternalContentMatch {
@@ -19,7 +20,11 @@ public class ExternalContentMatch {
 
     public ExternalContentMatch(String id, String type, int originalBegin, int originalEnd, List<ExternalContentMatch> externalContentMatches) {
         this(id, type, originalBegin, originalEnd);
-        this.externalContentMatches = externalContentMatches;
+        if(externalContentMatches == null) {
+            this.externalContentMatches = new ArrayList<>();
+        } else {
+            this.externalContentMatches = externalContentMatches;
+        }
     }
 
     public ExternalContentMatch(String id, String type, int originalBegin, int originalEnd) {
@@ -27,7 +32,7 @@ public class ExternalContentMatch {
         this.type = type;
         this.originalBegin = originalBegin;
         this.originalEnd = originalEnd;
-        this.externalContentMatches = null;
+        this.externalContentMatches = new ArrayList<>();
     }
 
     public String getId() {
@@ -56,7 +61,11 @@ public class ExternalContentMatch {
     }
 
     public void setExternalContentMatches( List<ExternalContentMatch> newList) {
-        externalContentMatches = newList;
+        if(newList == null) {
+            this.externalContentMatches = new ArrayList<>();
+        } else {
+            this.externalContentMatches = new ArrayList<>();
+        }
     }
 
     @Override

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/externalContent/ExternalContentMatch.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/externalContent/ExternalContentMatch.java
@@ -55,6 +55,10 @@ public class ExternalContentMatch {
         return externalContentMatches;
     }
 
+    public void setExternalContentMatches( List<ExternalContentMatch> newList) {
+        externalContentMatches = newList;
+    }
+
     @Override
     public String toString()
     {

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/externalContent/ExternalContentMatch.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/externalContent/ExternalContentMatch.java
@@ -64,7 +64,7 @@ public class ExternalContentMatch {
         if(newList == null) {
             this.externalContentMatches = new ArrayList<>();
         } else {
-            this.externalContentMatches = new ArrayList<>();
+            this.externalContentMatches = newList;
         }
     }
 

--- a/src/main/java/com/acrolinx/sidebar/utils/MatchUtils.java
+++ b/src/main/java/com/acrolinx/sidebar/utils/MatchUtils.java
@@ -46,6 +46,7 @@ public class MatchUtils
         }).collect(Collectors.toList());
     }
 
+    @java.lang.SuppressWarnings("java:S5852")
     public static boolean isExternalContentMatchAXMLTag(ExternalAbstractMatch match, List<ExternalContentField> lastCheckedExternalContent) {
         ExternalContentMatch externalContentMatch = match.getExternalContentMatches().get(0);
         while (!externalContentMatch.getExternalContentMatches().isEmpty()) {

--- a/src/main/java/com/acrolinx/sidebar/utils/MatchUtils.java
+++ b/src/main/java/com/acrolinx/sidebar/utils/MatchUtils.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.acrolinx.sidebar.pojo.document.ExternalAbstractMatch;
 import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentField;
 import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
 import org.slf4j.Logger;
@@ -31,8 +32,8 @@ public class MatchUtils
     {
         return list.stream().filter(m -> {
             //todo: does the external content contain tags that are not external content matches?
-            if (m.hasExternalContentMatches()) {
-                return isExternalContentMatchAXMLTag(m,lastCheckedExternalContent);
+            if (m instanceof ExternalAbstractMatch && ((ExternalAbstractMatch) m).hasExternalContentMatches()) {
+                return isExternalContentMatchAXMLTag((ExternalAbstractMatch) m,lastCheckedExternalContent);
             }
             String matchContent = lastCheckedContent.substring(m.getRange().getMinimumInteger(),
                     m.getRange().getMaximumInteger());
@@ -45,7 +46,7 @@ public class MatchUtils
         }).collect(Collectors.toList());
     }
 
-    public static boolean isExternalContentMatchAXMLTag(AbstractMatch match, List<ExternalContentField> lastCheckedExternalContent) {
+    public static boolean isExternalContentMatchAXMLTag(ExternalAbstractMatch match, List<ExternalContentField> lastCheckedExternalContent) {
         ExternalContentMatch externalContentMatch = match.getExternalContentMatches().get(0);
         while (externalContentMatch.getExternalContentMatches().size() > 0) {
             externalContentMatch = externalContentMatch.getExternalContentMatches().get(0);

--- a/src/main/java/com/acrolinx/sidebar/utils/MatchUtils.java
+++ b/src/main/java/com/acrolinx/sidebar/utils/MatchUtils.java
@@ -48,7 +48,7 @@ public class MatchUtils
 
     public static boolean isExternalContentMatchAXMLTag(ExternalAbstractMatch match, List<ExternalContentField> lastCheckedExternalContent) {
         ExternalContentMatch externalContentMatch = match.getExternalContentMatches().get(0);
-        while (externalContentMatch.getExternalContentMatches().size() > 0) {
+        while (!externalContentMatch.getExternalContentMatches().isEmpty()) {
             externalContentMatch = externalContentMatch.getExternalContentMatches().get(0);
         }
         final String externalContentId = externalContentMatch.getId();

--- a/src/main/java/com/acrolinx/sidebar/utils/MatchUtils.java
+++ b/src/main/java/com/acrolinx/sidebar/utils/MatchUtils.java
@@ -2,11 +2,13 @@
 
 package com.acrolinx.sidebar.utils;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
-import com.acrolinx.sidebar.pojo.document.AcrolinxMatch;
-import com.acrolinx.sidebar.pojo.document.AcrolinxMatchWithReplacement;
+import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentField;
+import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,22 +20,46 @@ public class MatchUtils
 
     private static final Logger logger = LoggerFactory.getLogger(SidebarUtils.class);
 
+
     public static List<? extends AbstractMatch> filterDangerousMatches(List<? extends AbstractMatch> list,
-            String lastCheckedContent)
+                                                                       String lastCheckedContent) {
+        return filterDangerousMatches(list,lastCheckedContent,new ArrayList<>());
+    }
+
+    public static List<? extends AbstractMatch> filterDangerousMatches(List<? extends AbstractMatch> list,
+                                                                       String lastCheckedContent, List<ExternalContentField> lastCheckedExternalContent)
     {
         return list.stream().filter(m -> {
             //todo: does the external content contain tags that are not external content matches?
-            if ( (m instanceof AcrolinxMatch) && ((AcrolinxMatch) m).hasExternalContentMatches()) return true;
+            if (m.hasExternalContentMatches()) {
+                return isExternalContentMatchAXMLTag(m,lastCheckedExternalContent);
+            }
             String matchContent = lastCheckedContent.substring(m.getRange().getMinimumInteger(),
                     m.getRange().getMaximumInteger());
             logger.debug("Checking if match is a tag");
-
 
             boolean isTag = matchContent.matches("</?\\w+.*?>");
             logger.debug("Is match a tag: " + isTag);
             return !isTag;
 
         }).collect(Collectors.toList());
+    }
+
+    public static boolean isExternalContentMatchAXMLTag(AbstractMatch match, List<ExternalContentField> lastCheckedExternalContent) {
+        ExternalContentMatch externalContentMatch = match.getExternalContentMatches().get(0);
+        while (externalContentMatch.getExternalContentMatches().size() > 0) {
+            externalContentMatch = externalContentMatch.getExternalContentMatches().get(0);
+        }
+        final String externalContentId = externalContentMatch.getId();
+        Optional<ExternalContentField> optionalExternalContentField = lastCheckedExternalContent.stream().filter(externalContentField -> externalContentField.getId().equals(externalContentId)).findFirst();
+        if(!optionalExternalContentField.isPresent()) {
+            logger.warn("Field for externalContentMatch has not been found");
+            return false;
+        }
+        ExternalContentField externalContentField = optionalExternalContentField.get();
+        String content = externalContentField.getContent();
+        String matchContent = content.substring(externalContentMatch.getRange().getMinimumInteger(),externalContentMatch.getRange().getMaximumInteger());
+        return !matchContent.matches("</?\\w+.*?>");
     }
 
 

--- a/src/test/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViewsTest.java
+++ b/src/test/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViewsTest.java
@@ -108,9 +108,13 @@ public class LookupForResolvedEditorViewsTest
                     }
 
                     @Override
-                    public String getAsXMLFragment()
+                    public ReferenceTreeNode getAsXMLFragment()
                     {
-                        return "<p><b>a</b> <u>apple</u></p>";
+                        ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
+                        String content =  "<p><b>a</b> <u>apple</u></p>";
+                        referenceTreeNode.setResolvedContent(content);
+                        referenceTreeNode.setUnresolvedContent(content);
+                        return referenceTreeNode;
                     }
                 });
         List<? extends AbstractMatch> matchesNew = abstractMatches.get();
@@ -172,9 +176,12 @@ public class LookupForResolvedEditorViewsTest
                     }
 
                     @Override
-                    public String getAsXMLFragment()
+                    public ReferenceTreeNode getAsXMLFragment()
                     {
-                        return null;
+                        ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
+                        referenceTreeNode.setUnresolvedContent("");
+                        referenceTreeNode.setResolvedContent("");
+                        return referenceTreeNode;
                     }
                 });
 
@@ -220,9 +227,11 @@ public class LookupForResolvedEditorViewsTest
                     }
 
                     @Override
-                    public String getAsXMLFragment()
+                    public ReferenceTreeNode getAsXMLFragment()
                     {
-                        return null;
+                        ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
+                        referenceTreeNode.setUnresolvedContent("");
+                        return referenceTreeNode;
                     }
                 });
 
@@ -267,9 +276,11 @@ public class LookupForResolvedEditorViewsTest
                     }
 
                     @Override
-                    public String getAsXMLFragment()
+                    public ReferenceTreeNode getAsXMLFragment()
                     {
-                        return null;
+                        ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
+                        referenceTreeNode.setUnresolvedContent("");
+                        return referenceTreeNode;
                     }
                 });
 
@@ -362,9 +373,10 @@ public class LookupForResolvedEditorViewsTest
             }
 
             @Override
-            public String getAsXMLFragment()
+            public ReferenceTreeNode getAsXMLFragment()
             {
-                return "<glossdef><?oxy_comment_end?> The flowers are very seasobable. Flower blooming in\n"
+                ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
+                String content = "<glossdef><?oxy_comment_end?> The flowers are very seasobable. Flower blooming in\n"
                         + "        <?oxy_comment_start author=\"shroti_kapartiwar\" timestamp=\"20170906T162356+0530\" comment=\"new line written\"?>winter<?oxy_comment_end?>\n"
                         + "        are very brigth and fresh. new data new line starts in div this mastake <sub>test</sub> page\n"
                         + "            <sup>spalling.</sup><table frame=\"all\" rowsep=\"1\" colsep=\"1\" id=\"table_lvy_4pv_t1b\">\n"
@@ -382,6 +394,10 @@ public class LookupForResolvedEditorViewsTest
                         + "                    <row>\n" + "                        <entry>wastee</entry>\n"
                         + "                        <entry>wastee</entry>\n" + "                    </row>\n"
                         + "                </tbody>\n" + "            </tgroup>\n" + "        </table></glossdef>";
+                referenceTreeNode.setUnresolvedContent(content);
+                referenceTreeNode.setResolvedContent(content);
+
+                return referenceTreeNode;
             }
         };
 
@@ -514,9 +530,11 @@ public class LookupForResolvedEditorViewsTest
             }
 
             @Override
-            public String getAsXMLFragment()
+            public ReferenceTreeNode getAsXMLFragment()
             {
-                return "<glossdef><?oxy_comment_end?> The flowers are very seasobable. Flower blooming in\n"
+                ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
+
+                String unresolvedContent = "<glossdef><?oxy_comment_end?> The flowers are very seasobable. Flower blooming in\n"
                         + "        <?oxy_comment_start author=\"shroti_kapartiwar\" timestamp=\"20170906T162356+0530\" comment=\"new line written\"?>winter<?oxy_comment_end?>\n"
                         + "        are very brigth and fresh. new data new line starts in div this mastake <sub>test</sub> page\n"
                         + "            <sup>spalling.</sup><table frame=\"all\" rowsep=\"1\" colsep=\"1\" id=\"table_lvy_4pv_t1b\">\n"
@@ -534,6 +552,9 @@ public class LookupForResolvedEditorViewsTest
                         + "                    <row>\n" + "                        <entry>wastee</entry>\n"
                         + "                        <entry>wastee</entry>\n" + "                    </row>\n"
                         + "                </tbody>\n" + "            </tgroup>\n" + "        </table></glossdef>";
+                referenceTreeNode.setUnresolvedContent(unresolvedContent);
+                referenceTreeNode.setResolvedContent(unresolvedContent);
+                return referenceTreeNode;
             }
         };
 
@@ -591,9 +612,13 @@ public class LookupForResolvedEditorViewsTest
             }
 
             @Override
-            public String getAsXMLFragment()
+            public ReferenceTreeNode getAsXMLFragment()
             {
-                return "<p>The &lt;caar&gt; is &lt;nicce&gt;.</p>";
+                ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
+                String content = "<p>The &lt;caar&gt; is &lt;nicce&gt;.</p>";
+                referenceTreeNode.setUnresolvedContent(content);
+                referenceTreeNode.setResolvedContent(content);
+                return referenceTreeNode;
             }
         };
 
@@ -664,9 +689,12 @@ public class LookupForResolvedEditorViewsTest
             }
 
             @Override
-            public String getAsXMLFragment()
+            public ReferenceTreeNode getAsXMLFragment()
             {
-                return contentNodeXMLString;
+                ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
+                referenceTreeNode.setUnresolvedContent(contentNodeXMLString);
+                referenceTreeNode.setResolvedContent(contentNodeString);
+                return referenceTreeNode;
             }
         };
 

--- a/src/test/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViewsTest.java
+++ b/src/test/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViewsTest.java
@@ -108,13 +108,9 @@ public class LookupForResolvedEditorViewsTest
                     }
 
                     @Override
-                    public ReferenceTreeNode getAsXMLFragment()
+                    public String getAsXMLFragment()
                     {
-                        ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
-                        String content =  "<p><b>a</b> <u>apple</u></p>";
-                        referenceTreeNode.setResolvedContent(content);
-                        referenceTreeNode.setUnresolvedContent(content);
-                        return referenceTreeNode;
+                        return "<p><b>a</b> <u>apple</u></p>";
                     }
                 });
         List<? extends AbstractMatch> matchesNew = abstractMatches.get();
@@ -176,12 +172,9 @@ public class LookupForResolvedEditorViewsTest
                     }
 
                     @Override
-                    public ReferenceTreeNode getAsXMLFragment()
+                    public String getAsXMLFragment()
                     {
-                        ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
-                        referenceTreeNode.setUnresolvedContent("");
-                        referenceTreeNode.setResolvedContent("");
-                        return referenceTreeNode;
+                        return "";
                     }
                 });
 
@@ -227,11 +220,9 @@ public class LookupForResolvedEditorViewsTest
                     }
 
                     @Override
-                    public ReferenceTreeNode getAsXMLFragment()
+                    public String getAsXMLFragment()
                     {
-                        ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
-                        referenceTreeNode.setUnresolvedContent("");
-                        return referenceTreeNode;
+                        return "";
                     }
                 });
 
@@ -276,11 +267,9 @@ public class LookupForResolvedEditorViewsTest
                     }
 
                     @Override
-                    public ReferenceTreeNode getAsXMLFragment()
+                    public String getAsXMLFragment()
                     {
-                        ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
-                        referenceTreeNode.setUnresolvedContent("");
-                        return referenceTreeNode;
+                        return "";
                     }
                 });
 
@@ -373,10 +362,9 @@ public class LookupForResolvedEditorViewsTest
             }
 
             @Override
-            public ReferenceTreeNode getAsXMLFragment()
+            public String getAsXMLFragment()
             {
-                ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
-                String content = "<glossdef><?oxy_comment_end?> The flowers are very seasobable. Flower blooming in\n"
+                return "<glossdef><?oxy_comment_end?> The flowers are very seasobable. Flower blooming in\n"
                         + "        <?oxy_comment_start author=\"shroti_kapartiwar\" timestamp=\"20170906T162356+0530\" comment=\"new line written\"?>winter<?oxy_comment_end?>\n"
                         + "        are very brigth and fresh. new data new line starts in div this mastake <sub>test</sub> page\n"
                         + "            <sup>spalling.</sup><table frame=\"all\" rowsep=\"1\" colsep=\"1\" id=\"table_lvy_4pv_t1b\">\n"
@@ -394,10 +382,6 @@ public class LookupForResolvedEditorViewsTest
                         + "                    <row>\n" + "                        <entry>wastee</entry>\n"
                         + "                        <entry>wastee</entry>\n" + "                    </row>\n"
                         + "                </tbody>\n" + "            </tgroup>\n" + "        </table></glossdef>";
-                referenceTreeNode.setUnresolvedContent(content);
-                referenceTreeNode.setResolvedContent(content);
-
-                return referenceTreeNode;
             }
         };
 
@@ -530,11 +514,9 @@ public class LookupForResolvedEditorViewsTest
             }
 
             @Override
-            public ReferenceTreeNode getAsXMLFragment()
+            public String getAsXMLFragment()
             {
-                ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
-
-                String unresolvedContent = "<glossdef><?oxy_comment_end?> The flowers are very seasobable. Flower blooming in\n"
+                return "<glossdef><?oxy_comment_end?> The flowers are very seasobable. Flower blooming in\n"
                         + "        <?oxy_comment_start author=\"shroti_kapartiwar\" timestamp=\"20170906T162356+0530\" comment=\"new line written\"?>winter<?oxy_comment_end?>\n"
                         + "        are very brigth and fresh. new data new line starts in div this mastake <sub>test</sub> page\n"
                         + "            <sup>spalling.</sup><table frame=\"all\" rowsep=\"1\" colsep=\"1\" id=\"table_lvy_4pv_t1b\">\n"
@@ -552,9 +534,6 @@ public class LookupForResolvedEditorViewsTest
                         + "                    <row>\n" + "                        <entry>wastee</entry>\n"
                         + "                        <entry>wastee</entry>\n" + "                    </row>\n"
                         + "                </tbody>\n" + "            </tgroup>\n" + "        </table></glossdef>";
-                referenceTreeNode.setUnresolvedContent(unresolvedContent);
-                referenceTreeNode.setResolvedContent(unresolvedContent);
-                return referenceTreeNode;
             }
         };
 
@@ -574,7 +553,7 @@ public class LookupForResolvedEditorViewsTest
             System.out.println(match.getRange().getMinimumInteger() + ", " + match.getRange().getMaximumInteger());
         });
 
-        Assert.assertTrue(matchesNew.size() == 7);
+        Assert.assertEquals(7,matchesNew.size());
 
         matchesNew.stream().forEach(
                 match -> Assert.assertTrue(rest_lookUpEditor.substring(match.getRange().getMinimumInteger(),
@@ -612,13 +591,9 @@ public class LookupForResolvedEditorViewsTest
             }
 
             @Override
-            public ReferenceTreeNode getAsXMLFragment()
+            public String getAsXMLFragment()
             {
-                ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
-                String content = "<p>The &lt;caar&gt; is &lt;nicce&gt;.</p>";
-                referenceTreeNode.setUnresolvedContent(content);
-                referenceTreeNode.setResolvedContent(content);
-                return referenceTreeNode;
+                return"<p>The &lt;caar&gt; is &lt;nicce&gt;.</p>";
             }
         };
 
@@ -689,12 +664,9 @@ public class LookupForResolvedEditorViewsTest
             }
 
             @Override
-            public ReferenceTreeNode getAsXMLFragment()
+            public String getAsXMLFragment()
             {
-                ReferenceTreeNode referenceTreeNode = new ReferenceTreeNode();
-                referenceTreeNode.setUnresolvedContent(contentNodeXMLString);
-                referenceTreeNode.setResolvedContent(contentNodeString);
-                return referenceTreeNode;
+                return contentNodeXMLString;
             }
         };
 

--- a/src/test/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViewsTest.java
+++ b/src/test/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViewsTest.java
@@ -693,15 +693,98 @@ public class LookupForResolvedEditorViewsTest
 
     }
 
-    /***
-     * This test covers the rare edge case where the contentnode's content appears twice in the document
-     * and the matchcontent also appears once in referenced content.
-     */
+
     @Test
-    public void testLookupReferencedContent()
+    public void testLookupInReferencedContent()
     {
         final String matchContent = "mistaake";
         final String contentNodeString = " "+matchContent+" ";
+        final String contentNodeResolvedXMLString = "<p>"+contentNodeString+"</p>";
+
+        final String authorViewContentBeforeContentNodeString = "Instructions for Authors.\n";
+        final String authorViewContent = authorViewContentBeforeContentNodeString + contentNodeString +"\n";
+        final String referencedContentTag = "<p conref=\"mistake-conref\"/>";
+
+        final String documentContentBeforeContentNode = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<!DOCTYPE topic PUBLIC \"-//OASIS//DTD DITA Topic//EN\" \"topic.dtd\">\n"
+                + "<topic id=\"topic_icd_txy_3db\">\n" + "<title>Instructions for Authors.</title>\n"
+                + "    <body>\n";
+        final String documentContentAfterContentNode = "\n    </body>\n" + "</topic>\n";
+        final String documentContent = documentContentBeforeContentNode + referencedContentTag +documentContentAfterContentNode;
+        ContentNode contentNode = new ExternalContentNode() {
+            @Override
+            public ReferenceTreeNode getReferenceTree() {
+                ReferenceTreeNode r = new ReferenceTreeNode();
+                r.setUnresolvedContent(referencedContentTag);
+                r.setResolvedContent(contentNodeResolvedXMLString);
+
+                ReferenceTreeNode externalContentNode = new ReferenceTreeNode();
+                externalContentNode.setResolvedContent(contentNodeResolvedXMLString);
+                externalContentNode.setUnresolvedContent(contentNodeResolvedXMLString);
+                externalContentNode.setStartOffsetInParent(0);
+                externalContentNode.setReferencingTag(referencedContentTag);
+                r.referenceChildren.add(externalContentNode);
+                return r;
+            }
+
+            @Override
+            public int getStartOffset()
+            {
+                return authorViewContentBeforeContentNodeString.length();
+            }
+
+            @Override
+            public int getEndOffset()
+            {
+                return authorViewContentBeforeContentNodeString.length() + contentNodeString.length();
+            }
+
+            @Override
+            public String getContent()
+            {
+                return contentNodeString;
+            }
+
+            @Override
+            public String getAsXMLFragment()
+            {
+                return referencedContentTag;
+            }
+
+        };
+
+        Assert.assertTrue(
+                authorViewContent.substring(contentNode.getStartOffset(), contentNode.getEndOffset()).equalsIgnoreCase(
+                        contentNode.getContent()));
+
+        ArrayList<AcrolinxMatch> matches = new ArrayList<>();
+
+        int pTagAndWhiteSpace = 4;
+        List<ExternalContentMatch> externalContentMatches = new ArrayList<>();
+        ExternalContentMatch externalContentMatch = new ExternalContentMatch("id","dita",pTagAndWhiteSpace,pTagAndWhiteSpace+matchContent.length());
+        externalContentMatches.add(externalContentMatch);
+        matches.add(new AcrolinxMatch(new IntRange(documentContentBeforeContentNode.length(), documentContentBeforeContentNode.length()+referencedContentTag.length()), matchContent,externalContentMatches));
+
+        LookupForResolvedEditorViews lookup = new LookupForResolvedEditorViews();
+        Optional<List<? extends AbstractMatch>> abstractMatches = lookup.matchRangesForResolvedEditorView(matches,
+                documentContent, authorViewContent, offset -> contentNode);
+
+        Assert.assertTrue(abstractMatches.isPresent());
+        AbstractMatch onlyMatch = abstractMatches.get().get(0);
+        IntRange matchRange = onlyMatch.getRange();
+        Assert.assertEquals(onlyMatch.getContent(),authorViewContent.substring(matchRange.getMinimumInteger(),
+                matchRange.getMaximumInteger()));
+        Assert.assertEquals(authorViewContentBeforeContentNodeString.length()+1,matchRange.getMinimumInteger());
+        Assert.assertEquals(authorViewContentBeforeContentNodeString.length()+1+matchContent.length(),matchRange.getMaximumInteger());
+
+    }
+
+
+    @Test
+    public void testLookupDuplicationInReferencedContent()
+    {
+        final String matchContent = "mistaake";
+        final String contentNodeString = " "+matchContent+" "+matchContent;
         final String contentNodeResolvedXMLString = "<p>"+contentNodeString+"</p>";
 
         final String authorViewContentBeforeContentNodeString = "Instructions for Authors.\n";

--- a/src/test/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViewsTest.java
+++ b/src/test/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViewsTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -689,6 +690,95 @@ public class LookupForResolvedEditorViewsTest
                 onlyMatch.getRange().getMaximumInteger()));
         Assert.assertEquals(authorViewContentBeforeContentNodeString.length()+1,onlyMatch.getRange().getMinimumInteger());
         Assert.assertEquals(authorViewContentBeforeContentNodeString.length()+1+matchContent.length(),onlyMatch.getRange().getMaximumInteger());
+
+    }
+
+    /***
+     * This test covers the rare edge case where the contentnode's content appears twice in the document
+     * and the matchcontent also appears once in referenced content.
+     */
+    @Test
+    public void testLookupReferencedContent()
+    {
+        final String matchContent = "mistaake";
+        final String contentNodeString = " "+matchContent+" ";
+        final String contentNodeResolvedXMLString = "<p>"+contentNodeString+"</p>";
+
+        final String authorViewContentBeforeContentNodeString = "Instructions for Authors.\n";
+        final String authorViewContent = authorViewContentBeforeContentNodeString + contentNodeString +"\n";
+        final String referencedContentTag = "<p conref=\"mistake-conref\"/>";
+
+        final String documentContentBeforeContentNode = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<!DOCTYPE topic PUBLIC \"-//OASIS//DTD DITA Topic//EN\" \"topic.dtd\">\n"
+                + "<topic id=\"topic_icd_txy_3db\">\n" + "<title>Instructions for Authors.</title>\n"
+                + "    <body>\n";
+        final String documentContentAfterContentNode = "\n    </body>\n" + "</topic>\n";
+        final String documentContent = documentContentBeforeContentNode + referencedContentTag +documentContentAfterContentNode;
+        ContentNode contentNode = new ExternalContentNode() {
+            @Override
+            public ReferenceTreeNode getReferenceTree() {
+                ReferenceTreeNode r = new ReferenceTreeNode();
+                r.setUnresolvedContent(referencedContentTag);
+                r.setResolvedContent(contentNodeResolvedXMLString);
+
+                ReferenceTreeNode externalContentNode = new ReferenceTreeNode();
+                externalContentNode.setResolvedContent(contentNodeResolvedXMLString);
+                externalContentNode.setUnresolvedContent(contentNodeResolvedXMLString);
+                externalContentNode.setStartOffsetInParent(0);
+                externalContentNode.setReferencingTag(referencedContentTag);
+                r.referenceChildren.add(externalContentNode);
+                return r;
+            }
+
+            @Override
+            public int getStartOffset()
+            {
+                return authorViewContentBeforeContentNodeString.length();
+            }
+
+            @Override
+            public int getEndOffset()
+            {
+                return authorViewContentBeforeContentNodeString.length() + contentNodeString.length();
+            }
+
+            @Override
+            public String getContent()
+            {
+                return contentNodeString;
+            }
+
+            @Override
+            public String getAsXMLFragment()
+            {
+                return referencedContentTag;
+            }
+
+        };
+
+        Assert.assertTrue(
+                authorViewContent.substring(contentNode.getStartOffset(), contentNode.getEndOffset()).equalsIgnoreCase(
+                        contentNode.getContent()));
+
+        ArrayList<AcrolinxMatch> matches = new ArrayList<>();
+
+        int pTagAndWhiteSpace = 4;
+        List<ExternalContentMatch> externalContentMatches = new ArrayList<>();
+        ExternalContentMatch externalContentMatch = new ExternalContentMatch("id","dita",pTagAndWhiteSpace,pTagAndWhiteSpace+matchContent.length());
+        externalContentMatches.add(externalContentMatch);
+        matches.add(new AcrolinxMatch(new IntRange(documentContentBeforeContentNode.length(), documentContentBeforeContentNode.length()+referencedContentTag.length()), matchContent,externalContentMatches));
+
+        LookupForResolvedEditorViews lookup = new LookupForResolvedEditorViews();
+        Optional<List<? extends AbstractMatch>> abstractMatches = lookup.matchRangesForResolvedEditorView(matches,
+                documentContent, authorViewContent, offset -> contentNode);
+
+        Assert.assertTrue(abstractMatches.isPresent());
+        AbstractMatch onlyMatch = abstractMatches.get().get(0);
+        IntRange matchRange = onlyMatch.getRange();
+        Assert.assertEquals(onlyMatch.getContent(),authorViewContent.substring(matchRange.getMinimumInteger(),
+                matchRange.getMaximumInteger()));
+        Assert.assertEquals(authorViewContentBeforeContentNodeString.length()+1,matchRange.getMinimumInteger());
+        Assert.assertEquals(authorViewContentBeforeContentNodeString.length()+1+matchContent.length(),matchRange.getMaximumInteger());
 
     }
 }

--- a/src/test/java/com/acrolinx/sidebar/pojo/document/CheckedDocumentPartTest.java
+++ b/src/test/java/com/acrolinx/sidebar/pojo/document/CheckedDocumentPartTest.java
@@ -27,6 +27,6 @@ public class CheckedDocumentPartTest
         CheckedDocumentPart partWithExternalContent = new CheckedDocumentPart("id0", new IntRange(2, 3), externalContentMatches);
         assertEquals("{checkId: \"id0\", range:[2,3], externalContent:[{" +
                 "\"id\":\"overview.dita\"," +
-                "\"type\":\"ditaReferences\",\"originalBegin\":25,\"originalEnd\":35,\"externalContentMatches\":[{\"id\":\"chapter11.dita\",\"type\":\"ditaReferences\",\"originalBegin\":75,\"originalEnd\":90}]}]}", partWithExternalContent.getAsJS());
+                "\"type\":\"ditaReferences\",\"originalBegin\":25,\"originalEnd\":35,\"externalContentMatches\":[{\"id\":\"chapter11.dita\",\"type\":\"ditaReferences\",\"originalBegin\":75,\"originalEnd\":90,\"externalContentMatches\":[]}]}]}", partWithExternalContent.getAsJS());
     }
 }


### PR DESCRIPTION
- add full support for checking of nested referenced content
- calculate the correct offset of external matches by traversing the tree of reference content
- optimize diffing of xml by replace \u0000 with a whitespace " "