### PR TITLE
DEV-31579 update libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -366,15 +366,15 @@ if (Integer.parseInt(Jvm.current().getJavaVersion().getMajorVersion()) >= 11) {
 dependencies {
 	// overwrite vulnerability in transitive dependencies...
 	api 'commons-beanutils:commons-beanutils:1.9.4'
-	api group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
+	api group: 'com.google.code.gson', name: 'gson', version: '2.10'
 	api group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
-    api group: 'org.apache.commons', name: 'commons-text', version: '1.9'
-	api group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.11'
-	api group: 'ch.qos.logback', name: 'logback-core', version: '1.2.11'
-	api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
+    api group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
+	api group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.4'
+	api group: 'ch.qos.logback', name: 'logback-core', version: '1.4.4'
+	api group: 'org.slf4j', name: 'slf4j-api', version: '2.0.3'
 	api group: 'commons-validator', name: 'commons-validator', version: '1.7'
 	api group: 'commons-io', name: 'commons-io', version: '2.11.0'
-	api group: 'org.jsoup', name: 'jsoup', version: '1.14.3'
+	api group: 'org.jsoup', name: 'jsoup', version: '1.15.3'
 	api 'com.google.guava:guava:31.0.1-jre'
 	compileOnly "org.eclipse.platform:$swtNatives:$SWT_VERSION"
 


### PR DESCRIPTION
## Dependency Updates

### Vulnerabilities 

commons-text -> 1.10.0  [CVE-2022-42889] Critical
jsoup -> 1.15.3  [CVE-2022-36033] Medium


### Other dependencies 

logback-classic -> 1.4.4
logback-core -> 1.4.4
gson -> 2.10
slf4j-api -> 2.0.3