### PR TITLE
chore: use format specifiers for logs rather than concatenation of strings

### DIFF
--- a/src/main/java/com/acrolinx/sidebar/jfx/AcrolinxSidebarJFX.java
+++ b/src/main/java/com/acrolinx/sidebar/jfx/AcrolinxSidebarJFX.java
@@ -58,7 +58,7 @@ public class AcrolinxSidebarJFX implements AcrolinxSidebar
         this.integration = integration;
         final String sidebarUrl = StartPageInstaller.prepareSidebarUrl(integration.getInitParameters());
 
-        logger.debug("Trying to load sidebar url: " + sidebarUrl);
+        logger.debug("Trying to load sidebar url: {}", sidebarUrl);
         final WebView webView = getWebView();
         final WebEngine webEngine = webView.getEngine();
         webEngine.setJavaScriptEnabled(true);
@@ -66,17 +66,17 @@ public class AcrolinxSidebarJFX implements AcrolinxSidebar
         webView.setCache(true);
         webView.setCacheHint(CacheHint.SPEED);
 
-        webEngine.setOnError((final WebErrorEvent arg0) -> logger.error("Error: " + arg0.getMessage()));
-        webEngine.setOnAlert((final WebEvent<String> arg0) -> logger.debug("Alert: " + arg0.getData()));
+        webEngine.setOnError((final WebErrorEvent arg0) -> logger.error("Error: {}", arg0.getMessage()));
+        webEngine.setOnAlert((final WebEvent<String> arg0) -> logger.debug("Alert: {}", arg0.getData()));
 
         webEngine.getLoadWorker().stateProperty().addListener((
                 final ObservableValue<? extends Worker.State> observedValue, final Worker.State oldState,
                 final Worker.State newState) -> this.getChangeListener(observedValue, oldState, newState, storage));
         webEngine.getLoadWorker().exceptionProperty().addListener(
-                (ov, t, t1) -> logger.error("webEngine exception: " + t1.getMessage()));
+                (ov, t, t1) -> logger.error("webEngine exception: {}", t1.getMessage()));
 
         if (sidebarUrl != null) {
-            logger.info("Loading: " + sidebarUrl);
+            logger.info("Loading: {}", sidebarUrl);
             webEngine.load(sidebarUrl);
         } else {
             // if sidebar url is not available show log file location
@@ -88,14 +88,14 @@ public class AcrolinxSidebarJFX implements AcrolinxSidebar
             final Worker.State oldState, final Worker.State newState, final AcrolinxStorage storage)
     {
 
-        logger.debug("state changed: " + observedValue.getValue() + ": " + oldState + " -> " + newState);
+        logger.debug("state changed: {} : {} -> {}", observedValue.getValue(), oldState, newState);
         if (newState == Worker.State.SUCCEEDED) {
             this.injectAcrolinxPlugin(storage);
         }
         if ("FAILED".equals("" + newState)) {
             final WebView webView = getWebView();
             final WebEngine webEngine = webView.getEngine();
-            logger.debug("New state: " + newState);
+            logger.debug("New state: {}", newState);
             // noinspection ThrowableResultOfMethodCallIgnored
             if (webEngine.getLoadWorker().getException() != null) {
                 // noinspection ThrowableResultOfMethodCallIgnored
@@ -109,7 +109,7 @@ public class AcrolinxSidebarJFX implements AcrolinxSidebar
     {
         final WebView webView = getWebView();
         final WebEngine webEngine = webView.getEngine();
-        logger.debug("Sidebar loaded from " + webEngine.getLocation());
+        logger.debug("Sidebar loaded from: {}", webEngine.getLocation());
         final JSObject jsobj = (JSObject) webEngine.executeScript("window");
         if (jsobj == null) {
             logger.error("Window Object null!");

--- a/src/main/java/com/acrolinx/sidebar/jfx/AcrolinxSidebarPluginWithOptions.java
+++ b/src/main/java/com/acrolinx/sidebar/jfx/AcrolinxSidebarPluginWithOptions.java
@@ -46,11 +46,11 @@ public class AcrolinxSidebarPluginWithOptions extends AcrolinxSidebarPlugin
                     initBatchCheck(batchCheckRequestOptions);
                     return true;
                 } catch (Exception e) {
-                    logger.error("Extracting references in Future Task failed", e.getMessage());
+                    logger.error("Extracting references in Future Task failed: {}", e.getMessage());
                     return false;
                 }
             });
-            logger.debug("Extracting references in Future task. Future task is running: " + !initBatchFuture.isDone());
+            logger.debug("Extracting references in Future task. Future task is running: {}", !initBatchFuture.isDone());
         } else {
             final CheckContent checkContent = getCheckContentFromClient();
             logger.debug("Fetched check content including external content");

--- a/src/main/java/com/acrolinx/sidebar/localization/Localizer.java
+++ b/src/main/java/com/acrolinx/sidebar/localization/Localizer.java
@@ -48,7 +48,7 @@ public class Localizer
             ResourceBundle.Control utf8Control = new UTF8ResourceBundleControl();
             this.resourceBundle = ResourceBundle.getBundle("localization/JavaSDK", locale, utf8Control);
             this.currentLocale = locale;
-            logger.debug("Locale changed to: " + locale);
+            logger.debug("Locale changed to: {}", locale);
         } catch (MissingResourceException e) {
             logger.error("Could not find locale resources.");
             logger.error(e.getMessage());

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
@@ -16,8 +16,7 @@ import org.slf4j.LoggerFactory;
 import com.acrolinx.sidebar.utils.DiffMatchPatch;
 
 @SuppressWarnings("WeakerAccess")
-public class LookupForResolvedEditorViews
-{
+public class LookupForResolvedEditorViews {
 
     private final Logger logger = LoggerFactory.getLogger(LookupForResolvedEditorViews.class);
 
@@ -27,8 +26,7 @@ public class LookupForResolvedEditorViews
 
     public Optional<List<? extends AbstractMatch>> matchRangesForResolvedEditorView(
             List<? extends AbstractMatch> adjustedRangesForCurrentDocument, String currentDocumentContent,
-            String resolvedViewContent, LookupForResolvedViewsHelper utils)
-    {
+            String resolvedViewContent, LookupForResolvedViewsHelper utils) {
 
         AtomicReference<List<AbstractMatch>> adjustedRangesCopyRef = new AtomicReference<>(new ArrayList<>());
 
@@ -72,7 +70,7 @@ public class LookupForResolvedEditorViews
                 boolean b = !filteredMatches.contains(match);
                 if (!b) {
                     logger.debug("Removing non found match because contains deleted whitespaces.");
-                    logger.debug(match.getRange().toString() + ", (" + match.getContent() + ")");
+                    logger.debug("{} ({})", match.getRange(), match.getContent());
                 }
                 return b;
             }).collect(Collectors.toList());
@@ -86,7 +84,7 @@ public class LookupForResolvedEditorViews
         Set<AbstractMatch> matchSet = new TreeSet<>(new MatchComparator());
         List<AbstractMatch> duplicates = newRanges.stream().filter(m -> !matchSet.add(m)).collect(Collectors.toList());
         for (AbstractMatch m : duplicates) {
-            logger.debug("Removing duplicate matched range: " + m.getRange().toString() + ", (" + m.getContent() + ")");
+            logger.debug("Removing duplicate matched range: {} ({})", m.getRange(), m.getContent());
             newRanges.remove(m);
         }
 
@@ -105,28 +103,26 @@ public class LookupForResolvedEditorViews
         return Optional.of(Collections.unmodifiableList(newRanges));
     }
 
-    private List<AbstractMatch> getCleanedMatchesWithoutIgnorableWhitespaces(List<AbstractMatch> adjustedRangesCopy)
-    {
+    private List<AbstractMatch> getCleanedMatchesWithoutIgnorableWhitespaces(List<AbstractMatch> adjustedRangesCopy) {
         return adjustedRangesCopy.stream().filter(match -> {
             logger.debug("Filter for ignorable whitespaces");
             boolean ignore = true;
             if (match instanceof AcrolinxMatchWithReplacement) {
                 logger.debug(((AcrolinxMatchWithReplacement) match).getReplacement());
                 ignore = "".equals(((AcrolinxMatchWithReplacement) match).getReplacement());
-                logger.debug("Replacement is empty? " + ignore);
+                logger.debug("Replacement is empty? {}", ignore);
             }
             logger.debug(match.getContent());
-            logger.debug("match content is space or empty? "
-                    + ("".equals(match.getContent()) || match.getContent().equalsIgnoreCase(" ")));
+            logger.debug("match content is space or empty? {}"
+                    , ("".equals(match.getContent()) || match.getContent().equalsIgnoreCase(" ")));
             boolean matchLineBreakOrTab = match.getContent().matches("[\\n\\r\\t]+");
-            logger.debug("match content is linebreak or tab? " + matchLineBreakOrTab);
-            return (("".equals(match.getContent()) || match.getContent().equals(" ")  || matchLineBreakOrTab) && ignore);
+            logger.debug("match content is linebreak or tab? {}", matchLineBreakOrTab);
+            return (("".equals(match.getContent()) || match.getContent().equals(" ") || matchLineBreakOrTab) && ignore);
         }).collect(Collectors.toList());
     }
 
     private void lookupMatchInContentNode(LookupForResolvedViewsHelper utils, List<? extends AbstractMatch> matches,
-            String currentDocumentContent)
-    {
+                                          String currentDocumentContent) {
 
         AtomicReference<String> nodeAsXML = new AtomicReference<>();
         AtomicReference<String> oldRelativFragment = new AtomicReference<>();
@@ -134,31 +130,31 @@ public class LookupForResolvedEditorViews
         AtomicReference<List<OffsetAlign>> offsetAligns = new AtomicReference<>();
 
         matches.forEach(match -> {
-            logger.debug("Mapping range for: " + match.getRange().toString() + ", (" + match.getContent() + ")");
+            logger.debug("Mapping range for: {} ({})", match.getRange(), match.getContent());
             ContentNode contentNode = utils.getContentNodeForOffsetInCurrentDocument(
                     match.getRange().getMinimumInteger());
             if (contentNode == null || contentNode.getContent() == null) return;
 
             int startOffset = contentNode.getStartOffset();
-            logger.debug("Lookup in node: " + contentNode.getContent());
-            logger.debug("Get node startOffset: " + contentNode.getStartOffset());
+            logger.debug("Lookup in node: {}", contentNode.getContent());
+            logger.debug("Get node startOffset: {}", contentNode.getStartOffset());
             String textContent = contentNode.getContent();
             String rangeContent = match.getContent();
-            if (StringUtils.countMatches(textContent, rangeContent) == 1 && (!(match instanceof ExternalAbstractMatch) ||!((ExternalAbstractMatch) match).hasExternalContentMatches() || ((ExternalAbstractMatch) match).getExternalContentMatches().size() < 2)) {
+            if (StringUtils.countMatches(textContent, rangeContent) == 1 && (!(match instanceof ExternalAbstractMatch) || !((ExternalAbstractMatch) match).hasExternalContentMatches() || ((ExternalAbstractMatch) match).getExternalContentMatches().size() < 2)) {
                 int i = textContent.indexOf(rangeContent);
                 AbstractMatch copy = match.setRange(
                         new IntRange(startOffset + i, startOffset + i + rangeContent.length()));
-                logger.debug("Found range for content by matching Strings: " + match.getContent());
+                logger.debug("Found range for content by matching Strings: {}", match.getContent());
                 logForDebugCurrentRanges(copy);
                 newRanges.add(copy);
                 mappedRanges.add(match);
             } else {
                 String contentNodeXMLString;
-                    // Try to lookup xml fragment in document.
+                // Try to lookup xml fragment in document.
                 Optional<IntRange> correctedMatchRange;
-                if(!(match instanceof ExternalAbstractMatch) || !((ExternalAbstractMatch) match).hasExternalContentMatches()) {
+                if (!(match instanceof ExternalAbstractMatch) || !((ExternalAbstractMatch) match).hasExternalContentMatches()) {
                     contentNodeXMLString = contentNode.getAsXMLFragment();
-                    if (contentNodeXMLString == null || contentNodeXMLString.equals("") ) return;
+                    if (contentNodeXMLString == null || contentNodeXMLString.equals("")) return;
                     final int fragmentStartOffsetInCurrentDocument = findFragmentStartOffsetInCurrentDocument(contentNodeXMLString, match);
                     final int fragmentEndOffsetInCurrentDocument = findFragmentEndOffsetInCurrentDocument(contentNodeXMLString, match, currentDocumentContent);
                     final String relativeFragment = currentDocumentContent.substring(fragmentStartOffsetInCurrentDocument, fragmentEndOffsetInCurrentDocument);
@@ -175,14 +171,14 @@ public class LookupForResolvedEditorViews
                             match.getRange().getMinimumInteger() - fragmentStartOffsetInCurrentDocument,
                             match.getRange().getMaximumInteger() - fragmentStartOffsetInCurrentDocument);
                 } else {
-                   if (contentNode instanceof ExternalContentNode) {
-                       ReferenceTreeNode xmlTree = ((ExternalContentNode) contentNode).getReferenceTree();
-                       contentNodeXMLString = xmlTree.getResolvedContent();
-                       correctedMatchRange = calcCorrectedMatch((ExternalAbstractMatch) match,xmlTree);
-                   } else {
-                       logger.error("Match has external content, but ContentNode is not of type ExternalContentNode");
-                       return;
-                   }
+                    if (contentNode instanceof ExternalContentNode) {
+                        ReferenceTreeNode xmlTree = ((ExternalContentNode) contentNode).getReferenceTree();
+                        contentNodeXMLString = xmlTree.getResolvedContent();
+                        correctedMatchRange = calcCorrectedMatch((ExternalAbstractMatch) match, xmlTree);
+                    } else {
+                        logger.error("Match has external content, but ContentNode is not of type ExternalContentNode");
+                        return;
+                    }
                 }
                 correctedMatchRange.ifPresent(range ->
                         diffXMLFragmentWithNodeContentFragment(match, contentNodeXMLString,
@@ -193,17 +189,18 @@ public class LookupForResolvedEditorViews
     }
 
     /**
-     *  Calcs Match offset as when the match and external content would just be part of the document
+     * Calcs Match offset as when the match and external content would just be part of the document
+     *
      * @param match
      * @param xmlTree
      * @return
      */
     private Optional<IntRange> calcCorrectedMatch(ExternalAbstractMatch match, ReferenceTreeNode xmlTree) {
-        if(!match.hasExternalContentMatches()) {
+        if (!match.hasExternalContentMatches()) {
             logger.error("calcCorrectedMatch was called despite match not having ExternalContentMatches");
             return Optional.empty();
         }
-        if(xmlTree.referenceChildren.isEmpty()) {
+        if (xmlTree.referenceChildren.isEmpty()) {
             logger.warn("No reference Children while match has external ContentMatches");
             return Optional.empty();
         }
@@ -212,16 +209,16 @@ public class LookupForResolvedEditorViews
         int totalDelta = 0;
         ReferenceTreeNode referencedContentTreeNode = xmlTree.referenceChildren.get(0);
 
-        while(referencedContentTreeNode != null && nextExternalContentMatch != null) {
+        while (referencedContentTreeNode != null && nextExternalContentMatch != null) {
             externalContentRange = nextExternalContentMatch.getRange();
             int externalContentRangeMinimum = externalContentRange.getMinimumInteger();
             List<ReferenceTreeNode> referenceChildren = referencedContentTreeNode.referenceChildren;
 
-            for(int i = 0; i < referenceChildren.size() && externalContentRangeMinimum > referenceChildren.get(i).getStartOffsetInParent(); i++) {
+            for (int i = 0; i < referenceChildren.size() && externalContentRangeMinimum > referenceChildren.get(i).getStartOffsetInParent(); i++) {
                 ReferenceTreeNode child = referencedContentTreeNode.referenceChildren.get(i);
                 int referenceTagLength = child.getReferencingTag().length();
                 int resolvedContentLength = child.getResolvedContent().length();
-                int delta = resolvedContentLength-referenceTagLength;
+                int delta = resolvedContentLength - referenceTagLength;
                 totalDelta += delta;
             }
 
@@ -230,8 +227,8 @@ public class LookupForResolvedEditorViews
             if (nextExternalContentMatch.getExternalContentMatches().isEmpty()) {
                 nextExternalContentMatch = null;
             } else {
-                Optional<ReferenceTreeNode> optionalReferenceTreeNode = referenceChildren.stream().filter( n -> n.getStartOffsetInParent() == externalContentRangeMinimum).findFirst();
-                if(optionalReferenceTreeNode.isPresent()) {
+                Optional<ReferenceTreeNode> optionalReferenceTreeNode = referenceChildren.stream().filter(n -> n.getStartOffsetInParent() == externalContentRangeMinimum).findFirst();
+                if (optionalReferenceTreeNode.isPresent()) {
                     referencedContentTreeNode = optionalReferenceTreeNode.get();
                 } else {
                     return Optional.empty();
@@ -242,8 +239,7 @@ public class LookupForResolvedEditorViews
         return Optional.of(new IntRange(totalDelta, totalDelta + externalContentRange.getMaximumInteger() - externalContentRange.getMinimumInteger()));
     }
 
-    private int findFragmentStartOffsetInCurrentDocument(String contentNodeXMLString, AbstractMatch match)
-    {
+    private int findFragmentStartOffsetInCurrentDocument(String contentNodeXMLString, AbstractMatch match) {
         final int contentFragmentLength = contentNodeXMLString.length();
         final int matchStartOffset = match.getRange().getMinimumInteger();
 
@@ -253,8 +249,7 @@ public class LookupForResolvedEditorViews
         return 0;
     }
 
-    private int findFragmentEndOffsetInCurrentDocument(String contentNodeXMLString, AbstractMatch match, String currentDocumentContent)
-    {
+    private int findFragmentEndOffsetInCurrentDocument(String contentNodeXMLString, AbstractMatch match, String currentDocumentContent) {
         final int contentFragmentLength = contentNodeXMLString.length();
         final int matchEndOffset = match.getRange().getMaximumInteger();
 
@@ -265,16 +260,15 @@ public class LookupForResolvedEditorViews
     }
 
     private void diffXMLFragmentWithNodeContentFragment(AbstractMatch match, String contentNodeXMLString, int startOffset,
-            String textContent, String rangeContent, IntRange range)
-    {
+                                                        String textContent, String rangeContent, IntRange range) {
         logger.debug(contentNodeXMLString);
         logger.debug(textContent);
-        textContent = textContent.replace("\u0000"," ");
+        textContent = textContent.replace("\u0000", " ");
         List<DiffMatchPatch.Diff> diffsNode = Lookup.getDiffs(contentNodeXMLString, textContent);
         List<OffsetAlign> offsetMappingArray = Lookup.createOffsetMappingArray(diffsNode);
 
         String rangeContentEscaped = StringEscapeUtils.escapeXml10(rangeContent);
-        logger.debug("Range Content escaped:" + rangeContentEscaped);
+        logger.debug("Range Content escaped: {}", rangeContentEscaped);
         // Deal with HTML entity
         if (!rangeContent.equals(rangeContentEscaped) && match.getRange().getMaximumInteger()
                 - match.getRange().getMinimumInteger() == rangeContentEscaped.length()) {
@@ -289,12 +283,11 @@ public class LookupForResolvedEditorViews
     }
 
     private void findRangeForHTMLEntity(AbstractMatch match, String contentNodeXMLString, int startOffset,
-            String textContent, String rangeContent, IntRange range, String rangeContentEscaped)
-    {
-        logger.debug("Has to find HTML entity " + rangeContentEscaped);
+                                        String textContent, String rangeContent, IntRange range, String rangeContentEscaped) {
+        logger.debug("Has to find HTML entity: {}", rangeContentEscaped);
         String cleanedAndEscapedTextContent = StringEscapeUtils.escapeXml10(textContent).replace(whitespaceCharacter, "");
 
-        logger.debug("Cleaned and escaped Text Content:" + cleanedAndEscapedTextContent);
+        logger.debug("Cleaned and escaped Text Content: {}", cleanedAndEscapedTextContent);
 
         List<DiffMatchPatch.Diff> diffsNodeForEntity = Lookup.getDiffs(contentNodeXMLString,
                 cleanedAndEscapedTextContent);
@@ -303,8 +296,8 @@ public class LookupForResolvedEditorViews
         Optional<Integer> diffOffsetPositionStart = Lookup.getDiffOffsetPositionStart(offsetMappingArrayForEntity,
                 range.getMinimumInteger() - 1);
         diffOffsetPositionStart.ifPresent(value -> {
-            logger.debug("Mapped to offset: " + value);
-            logger.debug("range min in is: " + range.getMinimumInteger());
+            logger.debug("Mapped to offset: {}", value);
+            logger.debug("range min in is: {}", range.getMinimumInteger());
             if ((range.getMinimumInteger() + value) >= 0) {
                 findRangeInResolvedText(match, contentNodeXMLString, startOffset, textContent, rangeContent, range, value);
             }
@@ -312,19 +305,18 @@ public class LookupForResolvedEditorViews
     }
 
     private void findRangeInResolvedText(AbstractMatch match, String contentNodeXMLString, int startOffset,
-            String textContent, String rangeContent, IntRange range, Integer value)
-    {
+                                         String textContent, String rangeContent, IntRange range, Integer value) {
         String textContentUpToMatch = contentNodeXMLString.substring(0, range.getMinimumInteger());
-        logger.debug("Text Content up to Match: " + textContentUpToMatch);
+        logger.debug("Text Content up to Match: {}", textContentUpToMatch);
         String textContentUpToMatchUnescaped = StringEscapeUtils.unescapeXml(textContentUpToMatch);
-        logger.debug("Text content up to match unescaped: " + textContentUpToMatchUnescaped);
+        logger.debug("Text content up to match unescaped: {}", textContentUpToMatchUnescaped);
         int entityDifference = textContentUpToMatch.length() - textContentUpToMatchUnescaped.length();
-        logger.debug("Entity difference is: " + entityDifference);
+        logger.debug("Entity difference is: {}", entityDifference);
         int offsetStart = range.getMinimumInteger() + value - entityDifference;
         String matchContent = textContent.substring(0, offsetStart + 1);
-        logger.debug("Match Content: " + matchContent);
+        logger.debug("Match Content: {}", matchContent);
         int leadingWhiteSpaces = matchContent.length() - matchContent.replace(whitespaceCharacter, "").length();
-        logger.debug("Leading whitespaces:  " + leadingWhiteSpaces);
+        logger.debug("Leading whitespaces: {}", leadingWhiteSpaces);
         offsetStart += leadingWhiteSpaces;
         int differedNullOffset = 0;
         while (textContent.substring(offsetStart + differedNullOffset, offsetStart + differedNullOffset + 1).matches(
@@ -332,12 +324,12 @@ public class LookupForResolvedEditorViews
             logger.debug("Offsets are null characters");
             differedNullOffset++;
         }
-        logger.debug("Differed null characters:" + differedNullOffset);
+        logger.debug("Differed null characters: {}", differedNullOffset);
         offsetStart += differedNullOffset;
-        logger.debug("Recalculated start offset: " + offsetStart);
+        logger.debug("Recalculated start offset: {}", offsetStart);
         int offsetEnd = offsetStart + 1;
-        logger.debug("Recalculated end offset: " + offsetEnd);
-        logger.debug("Text Content : " + textContent.substring(offsetStart, offsetEnd));
+        logger.debug("Recalculated end offset: {}", offsetEnd);
+        logger.debug("Text Content: {}", textContent.substring(offsetStart, offsetEnd));
         if (textContent.substring(offsetStart, offsetEnd).equals(rangeContent)) {
             addFoundRanges(match, startOffset, offsetStart, offsetEnd,
                     "Found range for html entity content by diffing content nodes: ");
@@ -346,21 +338,18 @@ public class LookupForResolvedEditorViews
     }
 
     private void addFoundRanges(AbstractMatch match, int startOffset, int offsetStart, int offsetEnd,
-            String debugMessage)
-    {
+                                String debugMessage) {
         AbstractMatch copy = match.setRange(new IntRange(startOffset + offsetStart, startOffset + offsetEnd));
-        logger.debug(debugMessage + match.getContent());
+        logger.debug("{} : {}", debugMessage, match.getContent());
         logForDebugCurrentRanges(copy);
         newRanges.add(copy);
         mappedRanges.add(match);
     }
 
     private void getMatchesWithCorrectedRangesIgnoreNonMatched(List<DiffMatchPatch.Diff> diffs,
-            List<OffsetAlign> offsetMappingArray, List<? extends AbstractMatch> matches)
-    {
+                                                               List<OffsetAlign> offsetMappingArray, List<? extends AbstractMatch> matches) {
         matches.forEach(match -> {
-            logger.debug("Mapping range for by diffing editors: " + match.getRange().toString() + ", ("
-                    + match.getContent() + ")");
+            logger.debug("Mapping range for by diffing editors: {} ({})", match.getRange(), match.getContent());
             Optional<IntRange> correctedMatch = Lookup.getCorrectedMatch(diffs, offsetMappingArray,
                     match.getRange().getMinimumInteger(), match.getRange().getMaximumInteger());
             if (correctedMatch.isPresent()) {
@@ -373,17 +362,16 @@ public class LookupForResolvedEditorViews
         });
     }
 
-    private void logForDebugFoundContent(AbstractMatch match)
-    {
-        logger.debug("Found range for content by diffing content nodes: " + match.getContent());
+    private void logForDebugFoundContent(AbstractMatch match) {
+        logger.debug("Found range for content by diffing content nodes: {}", match.getContent());
     }
 
     private void getMatchesByOccurrence(List<? extends AbstractMatch> matches, String currentDocumentContent,
-            String resolvedViewContent)
-    {
+                                        String resolvedViewContent) {
         matches.forEach(match -> {
             if (match.getContent().length() <= 1) return;
-            if (match instanceof ExternalAbstractMatch && ((ExternalAbstractMatch) match).hasExternalContentMatches()) return;
+            if (match instanceof ExternalAbstractMatch && ((ExternalAbstractMatch) match).hasExternalContentMatches())
+                return;
 
             String contentUpToMatch = currentDocumentContent.substring(0,
                     match.getRange().getMaximumInteger()).replaceAll("</?\\w+.*?>", "");
@@ -401,9 +389,8 @@ public class LookupForResolvedEditorViews
         });
     }
 
-    private void logForDebugCurrentRanges(AbstractMatch copy)
-    {
-        logger.debug("New range at: " + copy.getRange().toString());
+    private void logForDebugCurrentRanges(AbstractMatch copy) {
+        logger.debug("New range at: {}", copy.getRange());
     }
 
 }

--- a/src/main/java/com/acrolinx/sidebar/pojo/settings/AcrolinxSidebarInitParameter.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/settings/AcrolinxSidebarInitParameter.java
@@ -61,34 +61,33 @@ public class AcrolinxSidebarInitParameter
         this.minimumJavaVersion = builder.minimumJavaVersion;
         this.supported = builder.supported;
 
-        this.clientComponents.stream().forEach(component -> logger.info("Software component: " + component.toString()));
+        this.clientComponents.stream().forEach(component -> logger.info("Software component: {}", component));
         if (this.clientLocale != null) {
-            logger.info("Plugin initialized with client locale: " + this.clientLocale);
+            logger.info("Plugin initialized with client locale: {}", this.clientLocale);
         }
 
-        logger.info("Plugin running on Java VM: " + SidebarUtils.getSystemJavaVMName());
+        logger.info("Plugin running on Java VM: {}", SidebarUtils.getSystemJavaVMName());
 
         if (SidebarUtils.getSystemJavaVMName().indexOf("OpenJDK") < 0
                 && SidebarUtils.getSystemJavaVMName().indexOf("HotSpot") < 0) {
             logger.warn("You are using an unsupported Java VM. This might cause errors during runtime.");
         }
 
-        logger.info("Plugin running on Java VM Version: " + SidebarUtils.getFullCurrentJavaVersionString());
-        logger.info("Plugin running with JRE Path: " + SidebarUtils.getPathOfCurrentJavaJRE());
+        logger.info("Plugin running on Java VM Version: {}", SidebarUtils.getFullCurrentJavaVersionString());
+        logger.info("Plugin running with JRE Path: {}", SidebarUtils.getPathOfCurrentJavaJRE());
 
         if (this.minimumJavaVersion != 0) {
-            logger.info("Required Java Version is: " + this.minimumJavaVersion);
+            logger.info("Required Java Version is: {}", this.minimumJavaVersion);
             if (SidebarUtils.getSystemJavaVersion() < this.minimumJavaVersion) {
-                logger.warn("The current Java version " + SidebarUtils.getSystemJavaVersion()
-                        + " does not fulfill the requirements.");
+                logger.warn("The current Java version {} does not fulfill the requirements.", SidebarUtils.getSystemJavaVersion());
             }
         }
 
-        logger.info("Plugin initialized with force https: " + this.enforceHTTPS);
-        logger.info("Plugin initialized with enableSingleSignOn: " + this.enableSingleSignOn);
+        logger.info("Plugin initialized with force https: {}", this.enforceHTTPS);
+        logger.info("Plugin initialized with enableSingleSignOn: {}", this.enableSingleSignOn);
 
         if (this.minimumSidebarVersion != null) {
-            logger.info("Plugin expects minimum sidebar version: " + this.minimumSidebarVersion);
+            logger.info("Plugin expects minimum sidebar version: {}", this.minimumSidebarVersion);
         }
     }
 
@@ -125,7 +124,7 @@ public class AcrolinxSidebarInitParameter
     public void setClientLocale(final String clientLocale)
     {
         if ((this.clientLocale == null) || !this.clientLocale.equalsIgnoreCase(clientLocale)) {
-            logger.info("Set client locale to " + clientLocale);
+            logger.info("Set client locale to: {}", clientLocale);
             this.clientLocale = clientLocale;
         }
     }

--- a/src/main/java/com/acrolinx/sidebar/swing/AcrolinxMultiViewSidebarSwing.java
+++ b/src/main/java/com/acrolinx/sidebar/swing/AcrolinxMultiViewSidebarSwing.java
@@ -66,9 +66,9 @@ public class AcrolinxMultiViewSidebarSwing extends AcrolinxSidebarSwing implemen
 
                 for (AcrolinxSidebarJFX sidebarJFX : sidebars.values()) {
                     logger.debug("Component resized");
-                    logger.debug(getWidth() + " width");
+                    logger.debug("{} width", getWidth());
                     final float i = (float) getWidth() / 300;
-                    logger.debug(i + " Zoom");
+                    logger.debug("{} Zoom", i);
                     sidebarJFX.setZoom(i);
                 }
             }

--- a/src/main/java/com/acrolinx/sidebar/swing/AcrolinxSidebarSwing.java
+++ b/src/main/java/com/acrolinx/sidebar/swing/AcrolinxSidebarSwing.java
@@ -90,9 +90,9 @@ public class AcrolinxSidebarSwing extends JFXPanel implements AcrolinxSidebar
             public void componentResized(final ComponentEvent e)
             {
                 logger.debug("Component resized");
-                logger.debug(getWidth() + " width");
+                logger.debug("{} width", getWidth());
                 final float i = (float) getWidth() / 300;
-                logger.debug(i + " Zoom");
+                logger.debug("{} Zoom", i);
                 sidebarJFX.setZoom(i);
             }
 

--- a/src/main/java/com/acrolinx/sidebar/swt/AcrolinxSidebarSWT.java
+++ b/src/main/java/com/acrolinx/sidebar/swt/AcrolinxSidebarSWT.java
@@ -134,7 +134,7 @@ public class AcrolinxSidebarSWT implements AcrolinxSidebar
         browser.setJavascriptEnabled(true);
         try {
             final String sidebarUrl = StartPageInstaller.prepareSidebarUrl(client.getInitParameters());
-            logger.debug("Loading sidebar from " + sidebarUrl);
+            logger.debug("Loading sidebar from: {}", sidebarUrl);
             browser.setUrl(sidebarUrl);
         } catch (final Exception e) {
             logger.error("Error while loading sidebar!", e);
@@ -165,9 +165,9 @@ public class AcrolinxSidebarSWT implements AcrolinxSidebar
             public Object function(final Object[] arguments)
             {
                 final String key = arguments[0].toString();
-                logger.debug("Requesting " + key + " from local storage.");
+                logger.debug("Requesting {} from local storage.", key);
                 final String item = storage.getItem(key);
-                logger.debug("Got item: " + item);
+                logger.debug("Got item: {}", item);
                 return item;
             }
         };
@@ -177,7 +177,7 @@ public class AcrolinxSidebarSWT implements AcrolinxSidebar
             public Object function(final Object[] arguments)
             {
                 final String key = arguments[0].toString();
-                logger.debug("Removing " + key + " from local storage.");
+                logger.debug("Removing {} from local storage.", key);
                 storage.removeItem(key);
                 return null;
             }
@@ -198,7 +198,7 @@ public class AcrolinxSidebarSWT implements AcrolinxSidebar
     {
         final String key = arguments[0].toString();
         final String data = arguments[1].toString();
-        logger.debug("Setting " + key + " in local storage to " + data + ".");
+        logger.debug("Setting {} in local storage to {}.", key, data);
         storage.setItem(key, data);
         return null;
     }
@@ -209,7 +209,7 @@ public class AcrolinxSidebarSWT implements AcrolinxSidebar
             @Override
             public Object function(final Object[] arguments)
             {
-                logger.info("Java Script: " + arguments[0]);
+                logger.info("Java Script: {}", arguments[0]);
                 return null;
             }
         };
@@ -218,7 +218,7 @@ public class AcrolinxSidebarSWT implements AcrolinxSidebar
             @Override
             public Object function(final Object[] arguments)
             {
-                logger.debug("Java Script: " + arguments[0]);
+                logger.debug("Java Script: {}", arguments[0]);
                 return null;
             }
         };
@@ -340,27 +340,27 @@ public class AcrolinxSidebarSWT implements AcrolinxSidebar
 
     private String runCheckGlobal(Object checkSelection)
     {
-        Boolean selectionRequested = checkSelection.toString().equals("withCheckSelection") ? true : false;
-        logger.info("Check selection requested: " + selectionRequested);
+        boolean selectionRequested = checkSelection.toString().equals("withCheckSelection");
+        logger.info("Check selection requested: {}", selectionRequested);
 
         LogMessages.logCheckRequested(logger);
         checkStartTime.set(Instant.now());
 
         final String requestText = client.getEditorAdapter().getContent();
         currentlyCheckedText.set(requestText);
-        logger.debug("Request content: " + requestText);
+        logger.debug("Request content: {}", requestText);
 
         final String content = new Gson().toJson(requestText);
-        logger.debug("Request content JSON compatible: " + content);
+        logger.debug("Request content JSON compatible: {}", content);
 
         final ExternalContent externalContent = client.getEditorAdapter().getExternalContent();
         currentExternalContent.set(externalContent);
         if (externalContent != null) {
-            logger.debug("External Content: " + externalContent.toString());
+            logger.debug("External Content: {}", externalContent);
         }
 
         final CheckOptions checkOptions = getCheckSettingsFromClient(selectionRequested, externalContent);
-        logger.debug("Check options: " + checkOptions.toString());
+        logger.debug("Check options: {}", checkOptions);
 
         browser.execute("acrolinxSidebar.checkGlobal(" + content + "," + checkOptions.toString() + ");");
 
@@ -370,14 +370,14 @@ public class AcrolinxSidebarSWT implements AcrolinxSidebar
     private String requestCheckForDocumentInBatch(Object documentIdentifier)
     {
         final String docIdJsonString = new Gson().toJson(documentIdentifier);
-        logger.debug("Batch Check requested for: " + docIdJsonString);
+        logger.debug("Batch Check requested for: {}", docIdJsonString);
 
         final String contentForDocument = new Gson().toJson(
                 client.getContentForDocument(documentIdentifier.toString()));
-        logger.debug("Batch Check document content: " + contentForDocument);
+        logger.debug("Batch Check document content: {}", contentForDocument);
 
         final CheckOptions checkOptions = client.getCheckOptionsForDocument(documentIdentifier.toString());
-        logger.debug("Check ooptions for batch check document: " + checkOptions.toString());
+        logger.debug("Check ooptions for batch check document: {}", checkOptions);
 
         browser.execute("acrolinxSidebar.checkDocumentInBatch(" + docIdJsonString + ", " + contentForDocument + ", "
                 + checkOptions.toString() + ");");
@@ -390,10 +390,10 @@ public class AcrolinxSidebarSWT implements AcrolinxSidebar
         logger.info("Extracting references");
         try {
             List<BatchCheckRequestOptions> references = client.extractReferences();
-            logger.debug("Batch check document list: " + references.toString());
+            logger.debug("Batch check document list: {}", references.toString());
             initBatchCheck(references);
         } catch (Exception e) {
-            logger.error("Initializing batch check failed" + e.getMessage());
+            logger.error("Initializing batch check failed: {}", e.getMessage());
         }
         return null;
     }
@@ -408,13 +408,13 @@ public class AcrolinxSidebarSWT implements AcrolinxSidebar
     {
         ExecutorService executorService = Executors.newFixedThreadPool(1);
         Future<Boolean> openDocumentFuture = executorService.submit(() -> {
-            Boolean documentIsOpen = client.openDocumentInEditor(argument.toString());
+            boolean documentIsOpen = client.openDocumentInEditor(argument.toString());
             if (!documentIsOpen) {
                 // ToDo: Send a message to the sidebar
             }
             return documentIsOpen;
         });
-        logger.debug("Opening Document in Future task. Future task is running: " + !openDocumentFuture.isDone());
+        logger.debug("Opening Document in Future task. Future task is running: {}", !openDocumentFuture.isDone());
         return null;
     }
 
@@ -461,7 +461,7 @@ public class AcrolinxSidebarSWT implements AcrolinxSidebar
         } else if (SidebarUtils.isValidURL(url)) {
             Program.launch(url);
         } else {
-            logger.warn("Attempt to open invalid URL: " + url);
+            logger.warn("Attempt to open invalid URL: {}", url);
         }
         return null;
     }
@@ -640,7 +640,7 @@ public class AcrolinxSidebarSWT implements AcrolinxSidebar
     @Override
     public void showMessage(SidebarMessage sidebarMessage)
     {
-        logger.info("Message to be displayed on sidebar: " + sidebarMessage.toString());
+        logger.info("Message to be displayed on sidebar: {}", sidebarMessage.toString());
         browser.execute("window.acrolinxSidebar.showMessage(" + sidebarMessage.toString() + ")");
     }
 

--- a/src/main/java/com/acrolinx/sidebar/utils/LogMessages.java
+++ b/src/main/java/com/acrolinx/sidebar/utils/LogMessages.java
@@ -12,7 +12,7 @@ public class LogMessages
 {
     public static void logJavaVersionAndUIFramework(Logger logger, String uiFramework)
     {
-        logger.info("Java Version: " + System.getProperty("java.version") + "; UI Framework: " + uiFramework);
+        logger.info("Java Version: {} ; UI Framework: {}", System.getProperty("java.version"), uiFramework);
     }
 
     public static void logCheckRequested(Logger logger)
@@ -32,8 +32,7 @@ public class LogMessages
 
     public static void logCheckFinishedWithDurationTime(Logger logger, long durationTimeInMS)
     {
-        logger.info(
-                "Check finished. Check took " + DurationFormatUtils.formatDuration(durationTimeInMS, "HH:mm:ss,SSS"));
+        logger.info("Check finished. Check took {}", DurationFormatUtils.formatDuration(durationTimeInMS, "HH:mm:ss,SSS"));
     }
 
     public static void logSelectingRange(Logger logger)

--- a/src/main/java/com/acrolinx/sidebar/utils/MatchUtils.java
+++ b/src/main/java/com/acrolinx/sidebar/utils/MatchUtils.java
@@ -40,7 +40,7 @@ public class MatchUtils
             logger.debug("Checking if match is a tag");
 
             boolean isTag = matchContent.matches("</?\\w+.*?>");
-            logger.debug("Is match a tag: " + isTag);
+            logger.debug("Is match a tag: {}", isTag);
             return !isTag;
 
         }).collect(Collectors.toList());

--- a/src/main/java/com/acrolinx/sidebar/utils/SecurityUtils.java
+++ b/src/main/java/com/acrolinx/sidebar/utils/SecurityUtils.java
@@ -10,18 +10,15 @@ import org.slf4j.LoggerFactory;
 /**
  * For internal use.
  */
-public class SecurityUtils
-{
+public class SecurityUtils {
     private static final Logger logger = LoggerFactory.getLogger(SecurityUtils.class);
     final private static String ACRO_PREFIX = "acrolinx_force_";
 
-    private static void logPropertyValue(String propertyName, String propertyValue)
-    {
-        logger.info("Property " + propertyName + " is set to " + propertyValue);
+    private static void logPropertyValue(String propertyName, String propertyValue) {
+        logger.info("Property {} is set to {}", propertyName, propertyValue);
     }
 
-    public static void setUpEnvironment()
-    {
+    public static void setUpEnvironment() {
         String propertyNameAllowHeaders = "sun.net.http.allowRestrictedHeaders";
         String propertyRH = System.getProperty(propertyNameAllowHeaders);
         logPropertyValue(propertyNameAllowHeaders, propertyRH);
@@ -39,10 +36,10 @@ public class SecurityUtils
             String key = k.toString().toLowerCase();
             if (key.startsWith(ACRO_PREFIX)) {
                 logger.info("Setting up environment properties enforced by configuration.");
-                logger.info(key + ": " + v.toString());
+                logger.info("{} : {}", key, v);
                 System.setProperty(key.substring(ACRO_PREFIX.length()), v.toString());
-                logger.info(key.substring(ACRO_PREFIX.length()) + ": "
-                        + System.getProperty(key.substring(ACRO_PREFIX.length())));
+                logger.info("{} : {}", key.substring(ACRO_PREFIX.length()),
+                        System.getProperty(key.substring(ACRO_PREFIX.length())));
             }
         });
     }

--- a/src/main/java/com/acrolinx/sidebar/utils/SidebarUtils.java
+++ b/src/main/java/com/acrolinx/sidebar/utils/SidebarUtils.java
@@ -47,7 +47,7 @@ public class SidebarUtils
                 logger.error(e.getMessage());
             }
         } else {
-            logger.warn("Attempt to open invalid URL: " + url);
+            logger.warn("Attempt to open invalid URL: {}", url);
         }
     }
 
@@ -248,7 +248,7 @@ public class SidebarUtils
     private static boolean runCommand(final String command, final String args, final String file)
     {
 
-        logger.info("Trying to exec:\n   cmd = " + command + "\n   args = " + args + "\n   %s = " + file);
+        logger.info("Trying to exec:\n   cmd = {} \n   args = {} \n   %s = {}", command, args, file);
 
         final ArrayList<String> parts = new ArrayList<>();
         parts.add(command);

--- a/src/main/java/com/acrolinx/sidebar/utils/StartPageInstaller.java
+++ b/src/main/java/com/acrolinx/sidebar/utils/StartPageInstaller.java
@@ -94,7 +94,7 @@ public class StartPageInstaller
         Path serverSelectorDirectory = acrolinxDir.resolve(SERVER_SELECTOR_DIR + "_" + getStartPageVersion());
         if (!Files.exists(serverSelectorDirectory)) {
             serverSelectorDirectory = Files.createDirectories(serverSelectorDirectory);
-            logger.debug("Creating acrolinx start page directory in: " + serverSelectorDirectory.toString());
+            logger.debug("Creating acrolinx start page directory in: {}", serverSelectorDirectory.toString());
         }
         return serverSelectorDirectory;
     }

--- a/src/main/java/com/acrolinx/sidebar/utils/XMLLookupUtils.java
+++ b/src/main/java/com/acrolinx/sidebar/utils/XMLLookupUtils.java
@@ -97,7 +97,7 @@ public class XMLLookupUtils
             endOffset = StringUtils.ordinalIndexOf(xmlContent, endTagInXML, occurrencesOfEndTag + 1) + endTagInXML.length();
 
         } catch (XPathExpressionException | ParserConfigurationException | IOException | SAXException e) {
-            logger.error("Unable to find offsets in XMl for xpath : ".concat(xpath));
+            logger.error("Unable to find offsets in XMl for xpath: {}", xpath);
             logger.error(e.getMessage());
         } catch (IllegalStateException e) {
             logger.error(e.getMessage());


### PR DESCRIPTION
This is to make use of the formatting provided by Log4j. Using Sonarlint in your IDE recommends this and it's quite neat.