### PR TITLE
Change package name externalContent to externalcontent

### DIFF
--- a/src/main/java/com/acrolinx/sidebar/InputAdapterInterface.java
+++ b/src/main/java/com/acrolinx/sidebar/InputAdapterInterface.java
@@ -6,7 +6,7 @@ import java.util.List;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatch;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatchWithReplacement;
 import com.acrolinx.sidebar.pojo.document.IntRange;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContent;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContent;
 import com.acrolinx.sidebar.pojo.settings.InputFormat;
 
 /**

--- a/src/main/java/com/acrolinx/sidebar/adapter/NullEditorAdapter.java
+++ b/src/main/java/com/acrolinx/sidebar/adapter/NullEditorAdapter.java
@@ -8,7 +8,7 @@ import com.acrolinx.sidebar.InputAdapterInterface;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatch;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatchWithReplacement;
 import com.acrolinx.sidebar.pojo.document.IntRange;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContent;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContent;
 import com.acrolinx.sidebar.pojo.settings.InputFormat;
 
 /**

--- a/src/main/java/com/acrolinx/sidebar/jfx/AcrolinxSidebarJFX.java
+++ b/src/main/java/com/acrolinx/sidebar/jfx/AcrolinxSidebarJFX.java
@@ -19,7 +19,7 @@ import com.acrolinx.sidebar.AcrolinxSidebar;
 import com.acrolinx.sidebar.AcrolinxStorage;
 import com.acrolinx.sidebar.pojo.document.AbstractMatch;
 import com.acrolinx.sidebar.pojo.document.CheckedDocumentPart;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContent;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContent;
 import com.acrolinx.sidebar.pojo.settings.BatchCheckRequestOptions;
 import com.acrolinx.sidebar.pojo.settings.CheckOptions;
 import com.acrolinx.sidebar.pojo.settings.PluginSupportedParameters;

--- a/src/main/java/com/acrolinx/sidebar/jfx/AcrolinxSidebarPlugin.java
+++ b/src/main/java/com/acrolinx/sidebar/jfx/AcrolinxSidebarPlugin.java
@@ -29,7 +29,7 @@ import com.acrolinx.sidebar.pojo.document.CheckContent;
 import com.acrolinx.sidebar.pojo.document.CheckResult;
 import com.acrolinx.sidebar.pojo.document.CheckedDocumentPart;
 import com.acrolinx.sidebar.pojo.document.IntRange;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContent;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContent;
 import com.acrolinx.sidebar.pojo.settings.AcrolinxPluginConfiguration;
 import com.acrolinx.sidebar.pojo.settings.AcrolinxSidebarInitParameter;
 import com.acrolinx.sidebar.pojo.settings.BatchCheckRequestOptions;

--- a/src/main/java/com/acrolinx/sidebar/jfx/JSToJavaConverter.java
+++ b/src/main/java/com/acrolinx/sidebar/jfx/JSToJavaConverter.java
@@ -17,7 +17,7 @@ import com.acrolinx.sidebar.pojo.document.AcrolinxMatchWithReplacement;
 import com.acrolinx.sidebar.pojo.document.CheckResult;
 import com.acrolinx.sidebar.pojo.document.CheckedDocumentPart;
 import com.acrolinx.sidebar.pojo.document.IntRange;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentMatch;
 import com.acrolinx.sidebar.pojo.settings.AcrolinxPluginConfiguration;
 import com.google.common.collect.Lists;
 

--- a/src/main/java/com/acrolinx/sidebar/jfx/adapter/TextAreaAdapter.java
+++ b/src/main/java/com/acrolinx/sidebar/jfx/adapter/TextAreaAdapter.java
@@ -12,7 +12,7 @@ import com.acrolinx.sidebar.lookup.MatchComparator;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatch;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatchWithReplacement;
 import com.acrolinx.sidebar.pojo.document.IntRange;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContent;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContent;
 import com.acrolinx.sidebar.pojo.settings.InputFormat;
 
 public class TextAreaAdapter implements InputAdapterInterface

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViews.java
@@ -19,7 +19,7 @@ import com.acrolinx.sidebar.pojo.document.AbstractMatch;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatchWithReplacement;
 import com.acrolinx.sidebar.pojo.document.ExternalAbstractMatch;
 import com.acrolinx.sidebar.pojo.document.IntRange;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentMatch;
 import com.acrolinx.sidebar.utils.DiffMatchPatch;
 
 public class LookupForResolvedEditorViews

--- a/src/main/java/com/acrolinx/sidebar/lookup/LookupRangesDiff.java
+++ b/src/main/java/com/acrolinx/sidebar/lookup/LookupRangesDiff.java
@@ -14,9 +14,9 @@ import com.acrolinx.sidebar.LookupRanges;
 import com.acrolinx.sidebar.pojo.document.AbstractMatch;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatch;
 import com.acrolinx.sidebar.pojo.document.IntRange;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContent;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentField;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContent;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentField;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentMatch;
 import com.acrolinx.sidebar.utils.DiffMatchPatch;
 
 public class LookupRangesDiff extends LookupRanges

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/AcrolinxMatch.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/AcrolinxMatch.java
@@ -3,7 +3,7 @@ package com.acrolinx.sidebar.pojo.document;
 
 import java.util.List;
 
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentMatch;
 
 public class AcrolinxMatch extends ExternalAbstractMatch
 {

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/AcrolinxMatchFromJSON.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/AcrolinxMatchFromJSON.java
@@ -3,7 +3,7 @@ package com.acrolinx.sidebar.pojo.document;
 
 import java.util.List;
 
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentMatch;
 
 public class AcrolinxMatchFromJSON
 {

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/AcrolinxMatchWithReplacement.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/AcrolinxMatchWithReplacement.java
@@ -3,7 +3,7 @@ package com.acrolinx.sidebar.pojo.document;
 
 import java.util.List;
 
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentMatch;
 
 public class AcrolinxMatchWithReplacement extends AcrolinxMatch
 {

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/CheckContent.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/CheckContent.java
@@ -3,8 +3,8 @@ package com.acrolinx.sidebar.pojo.document;
 
 import javax.annotation.Nullable;
 
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContent;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentBuilder;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContent;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentBuilder;
 import com.google.gson.Gson;
 
 public class CheckContent

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/CheckedDocumentPart.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/CheckedDocumentPart.java
@@ -3,7 +3,7 @@ package com.acrolinx.sidebar.pojo.document;
 
 import java.util.List;
 
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentMatch;
 import com.google.gson.Gson;
 
 public class CheckedDocumentPart

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/ExternalAbstractMatch.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/ExternalAbstractMatch.java
@@ -3,7 +3,7 @@ package com.acrolinx.sidebar.pojo.document;
 
 import java.util.List;
 
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentMatch;
 
 public abstract class ExternalAbstractMatch extends AbstractMatch
 {

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/externalcontent/ExternalContent.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/externalcontent/ExternalContent.java
@@ -1,5 +1,5 @@
 /* Copyright (c) 2018-present Acrolinx GmbH */
-package com.acrolinx.sidebar.pojo.document.externalContent;
+package com.acrolinx.sidebar.pojo.document.externalcontent;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/externalcontent/ExternalContentBuilder.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/externalcontent/ExternalContentBuilder.java
@@ -1,5 +1,5 @@
 /* Copyright (c) 2018-present Acrolinx GmbH */
-package com.acrolinx.sidebar.pojo.document.externalContent;
+package com.acrolinx.sidebar.pojo.document.externalcontent;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/externalcontent/ExternalContentField.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/externalcontent/ExternalContentField.java
@@ -1,5 +1,5 @@
 /* Copyright (c) 2018-present Acrolinx GmbH */
-package com.acrolinx.sidebar.pojo.document.externalContent;
+package com.acrolinx.sidebar.pojo.document.externalcontent;
 
 import com.google.gson.Gson;
 

--- a/src/main/java/com/acrolinx/sidebar/pojo/document/externalcontent/ExternalContentMatch.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/externalcontent/ExternalContentMatch.java
@@ -1,5 +1,5 @@
 /* Copyright (c) 2018-present Acrolinx GmbH */
-package com.acrolinx.sidebar.pojo.document.externalContent;
+package com.acrolinx.sidebar.pojo.document.externalcontent;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/acrolinx/sidebar/pojo/settings/CheckOptions.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/settings/CheckOptions.java
@@ -3,7 +3,7 @@ package com.acrolinx.sidebar.pojo.settings;
 
 import javax.annotation.Nullable;
 
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContent;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContent;
 import com.google.gson.Gson;
 
 /**

--- a/src/main/java/com/acrolinx/sidebar/swing/AcrolinxSidebarSwing.java
+++ b/src/main/java/com/acrolinx/sidebar/swing/AcrolinxSidebarSwing.java
@@ -24,7 +24,7 @@ import com.acrolinx.sidebar.jfx.AcrolinxSidebarJFX;
 import com.acrolinx.sidebar.jfx.JFXUtils;
 import com.acrolinx.sidebar.pojo.document.AbstractMatch;
 import com.acrolinx.sidebar.pojo.document.CheckedDocumentPart;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContent;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContent;
 import com.acrolinx.sidebar.pojo.settings.BatchCheckRequestOptions;
 import com.acrolinx.sidebar.pojo.settings.CheckOptions;
 import com.acrolinx.sidebar.pojo.settings.SidebarConfiguration;

--- a/src/main/java/com/acrolinx/sidebar/swing/adapter/TextAreaAdapter.java
+++ b/src/main/java/com/acrolinx/sidebar/swing/adapter/TextAreaAdapter.java
@@ -17,7 +17,7 @@ import com.acrolinx.sidebar.lookup.MatchComparator;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatch;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatchWithReplacement;
 import com.acrolinx.sidebar.pojo.document.IntRange;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContent;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContent;
 import com.acrolinx.sidebar.pojo.settings.InputFormat;
 
 /**

--- a/src/main/java/com/acrolinx/sidebar/swt/AcrolinxSidebarSWT.java
+++ b/src/main/java/com/acrolinx/sidebar/swt/AcrolinxSidebarSWT.java
@@ -45,7 +45,7 @@ import com.acrolinx.sidebar.pojo.document.CheckResult;
 import com.acrolinx.sidebar.pojo.document.CheckResultFromJSON;
 import com.acrolinx.sidebar.pojo.document.CheckedDocumentPart;
 import com.acrolinx.sidebar.pojo.document.IntRange;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContent;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContent;
 import com.acrolinx.sidebar.pojo.settings.AcrolinxURL;
 import com.acrolinx.sidebar.pojo.settings.BatchCheckRequestOptions;
 import com.acrolinx.sidebar.pojo.settings.CheckOptions;

--- a/src/main/java/com/acrolinx/sidebar/swt/adapter/TextAdapter.java
+++ b/src/main/java/com/acrolinx/sidebar/swt/adapter/TextAdapter.java
@@ -13,7 +13,7 @@ import com.acrolinx.sidebar.lookup.MatchComparator;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatch;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatchWithReplacement;
 import com.acrolinx.sidebar.pojo.document.IntRange;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContent;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContent;
 import com.acrolinx.sidebar.pojo.settings.InputFormat;
 
 /**

--- a/src/main/java/com/acrolinx/sidebar/utils/MatchUtils.java
+++ b/src/main/java/com/acrolinx/sidebar/utils/MatchUtils.java
@@ -11,8 +11,8 @@ import org.slf4j.LoggerFactory;
 
 import com.acrolinx.sidebar.pojo.document.AbstractMatch;
 import com.acrolinx.sidebar.pojo.document.ExternalAbstractMatch;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentField;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentField;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentMatch;
 import com.google.common.collect.Lists;
 
 public final class MatchUtils

--- a/src/test/java/com/acrolinx/sidebar/dita/ExternalContentTest.java
+++ b/src/test/java/com/acrolinx/sidebar/dita/ExternalContentTest.java
@@ -11,9 +11,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 import com.acrolinx.sidebar.pojo.document.CheckContent;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContent;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentBuilder;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentField;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContent;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentBuilder;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentField;
 
 class ExternalContentTest
 {

--- a/src/test/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViewsTest.java
+++ b/src/test/java/com/acrolinx/sidebar/lookup/LookupForResolvedEditorViewsTest.java
@@ -12,7 +12,7 @@ import com.acrolinx.sidebar.pojo.document.AbstractMatch;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatch;
 import com.acrolinx.sidebar.pojo.document.AcrolinxMatchWithReplacement;
 import com.acrolinx.sidebar.pojo.document.IntRange;
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentMatch;
 
 class LookupForResolvedEditorViewsTest
 {

--- a/src/test/java/com/acrolinx/sidebar/pojo/document/CheckedDocumentPartTest.java
+++ b/src/test/java/com/acrolinx/sidebar/pojo/document/CheckedDocumentPartTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import com.acrolinx.sidebar.pojo.document.externalContent.ExternalContentMatch;
+import com.acrolinx.sidebar.pojo.document.externalcontent.ExternalContentMatch;
 
 class CheckedDocumentPartTest
 {


### PR DESCRIPTION
Conform to best practices when naming Java packages

Resolves: DEV-32041