### PR TITLE
Returning an empty map instead of null.

### DIFF
--- a/src/main/java/com/acrolinx/sidebar/pojo/document/CheckResultFromJSON.java
+++ b/src/main/java/com/acrolinx/sidebar/pojo/document/CheckResultFromJSON.java
@@ -30,7 +30,7 @@ public class CheckResultFromJSON {
     final Map<String, String> map = new LinkedHashMap<>();
 
     if (embedCheckInformation == null) {
-      return null;
+      return new LinkedHashMap<>();
     }
 
     for (final CheckInformationKeyValuePairFromJSON checkInformationKeyValuePairFromJSON :


### PR DESCRIPTION
Returning null by a method having return type as a HashMap, demands extra check for nullity which can be complex. Instead of that, we can simply pass an empty HashMap of required type to ensure smooth execution.